### PR TITLE
[doc] Add docs for enabling CLI autocompletion

### DIFF
--- a/README.org
+++ b/README.org
@@ -76,6 +76,38 @@ run =minijuvix --help=.
   |-----------+------------------+-------------------------------------------------------|
   | =C-c C-l= | =minijuvix-load= | Runs the scoper and adds semantic syntax highlighting |
 
+** CLI Auto-completion Scripts
+
+The MiniJuvix CLI can generate auto-completion scripts. Follow the instructions below for your shell.
+
+NB: You may need to restart your shell after installing the completion script.
+
+*** Bash
+
+Add the following line to your bash init script (for example =~/.bashrc=).
+
+#+begin_src shell
+  eval "$(minijuvix --bash-completion-script minijuvix)"
+#+end_src
+
+*** Fish
+
+Run the following command in your shell:
+
+#+begin_src shell
+  $ minijuvix --fish-completion-script minijuvix > ~/.config/fish/completions/minijuvix.fish
+#+end_src
+
+*** ZSH
+
+Run the following command in your shell:
+
+#+begin_src shell
+  $ minijuvix --zsh-completion-script minijuvix > $DIR_IN_FPATH/_minijuvix
+#+end_src
+
+where =$DIR_IN_FPATH= is a directory that is present on the [[https://zsh.sourceforge.io/Doc/Release/Functions.html][ZSH FPATH variable]] (which you can inspect by running =echo $FPATH= in the shell).
+
 ** Community
 
 We would love to hear what you think of MiniJuvix! Join us on


### PR DESCRIPTION
Adds documentation for enabling CLI autocompletion for bash, fish and zsh shells using the autogenerated scripts obtained from optparse-applicative.

Completes: https://github.com/heliaxdev/minijuvix/issues/23