### PR TITLE
Short-circuit clause pattern check errors

### DIFF
--- a/test/TypeCheck/Negative.hs
+++ b/test/TypeCheck/Negative.hs
@@ -86,5 +86,12 @@ tests =
       "MultiWrongType.mjuvix"
       $ \case
         (TypeCheckerErrors (ErrWrongType {} :| [ErrWrongType {}])) -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Constructor pattern with arity greater than the constructor"
+      "MicroJuvix"
+      "WrongConstructorArity.mjuvix"
+      $ \case
+        (TypeCheckerErrors (ErrWrongConstructorAppArgs {} :| [])) -> Nothing
         _ -> wrongError
   ]

--- a/tests/negative/MicroJuvix/WrongConstructorArity.mjuvix
+++ b/tests/negative/MicroJuvix/WrongConstructorArity.mjuvix
@@ -1,0 +1,8 @@
+module WrongConstructorArity;
+  inductive T {
+    A : T;
+  };
+
+  f : T → T;
+  f (A i) ≔ i;
+end;


### PR DESCRIPTION
In the following case:

```
module WrongConstructorArity;
  inductive T {
    A : T;
  };

  f : T → T;
  f (A i) ≔ i;
end;
```

The typechecker fails when checking the clause `f (A i) := i` because of
the extra constructor argument. However if typechecking continues then
the variable `i` on the rhs does not have a type so we must short-circuit.