### PR TITLE
Output ANSI codes only if handle supports it

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -27,7 +27,8 @@ import MiniJuvix.Syntax.MicroJuvix.Error qualified as Micro
 import MiniJuvix.Syntax.MicroJuvix.Language qualified as Micro
 import MiniJuvix.Syntax.MicroJuvix.Pretty.Ansi qualified as Micro
 import MiniJuvix.Syntax.MicroJuvix.TypeChecker qualified as Micro
-import MiniJuvix.Syntax.MiniHaskell.Pretty.Ansi qualified as Hask
+import MiniJuvix.Syntax.MiniHaskell.Pretty.Ansi qualified as HaskAnsi
+import MiniJuvix.Syntax.MiniHaskell.Pretty.Text qualified as HaskText
 import MiniJuvix.Termination qualified as T
 import MiniJuvix.Termination.CallGraph qualified as A
 import MiniJuvix.Translation.AbstractToMicroJuvix qualified as Micro
@@ -36,6 +37,8 @@ import MiniJuvix.Translation.ScopedToAbstract qualified as Abstract
 import MiniJuvix.Utils.Version (runDisplayVersion)
 import Options.Applicative
 import Options.Applicative.Help.Pretty
+import System.Console.ANSI qualified as Ansi
+import System.IO qualified as IO
 import Text.Show.Pretty hiding (Html)
 
 --------------------------------------------------------------------------------
@@ -358,7 +361,10 @@ runCommand c = do
       case Micro.checkModule micro of
         Right checkedMicro -> do
           minihaskell <- fromRightIO' putStrLn (return $ Hask.translateModule checkedMicro)
-          Hask.printPrettyCodeDefault minihaskell
+          supportsAnsi <- Ansi.hSupportsANSI IO.stdout
+          if supportsAnsi
+            then HaskAnsi.printPrettyCodeDefault minihaskell
+            else HaskText.printPrettyCodeDefault minihaskell
         Left es -> printErrorAnsi es >> exitFailure
     Termination (Calls opts@CallsOptions {..}) -> do
       a <- head . (^. Abstract.resultModules) <$> runIO (upToAbstract (getEntryPoint root opts))

--- a/package.yaml
+++ b/package.yaml
@@ -96,6 +96,7 @@ executables:
     main: Main.hs
     source-dirs: app
     dependencies:
+    - ansi-terminal == 0.11.*
     - minijuvix
     - optparse-applicative == 0.17.*
     verbatim:

--- a/src/MiniJuvix/Syntax/MiniHaskell/Pretty/Text.hs
+++ b/src/MiniJuvix/Syntax/MiniHaskell/Pretty/Text.hs
@@ -1,0 +1,29 @@
+module MiniJuvix.Syntax.MiniHaskell.Pretty.Text where
+
+import MiniJuvix.Prelude
+import MiniJuvix.Syntax.MiniHaskell.Pretty.Ann
+import MiniJuvix.Syntax.MiniHaskell.Pretty.Base
+import Prettyprinter
+import Prettyprinter.Render.Text
+
+printPrettyCodeDefault :: PrettyCode c => c -> IO ()
+printPrettyCodeDefault = printPrettyCode defaultOptions
+
+printPrettyCode :: PrettyCode c => Options -> c -> IO ()
+printPrettyCode = hPrintPrettyCode stdout
+
+hPrintPrettyCode :: PrettyCode c => Handle -> Options -> c -> IO ()
+hPrintPrettyCode h opts = renderIO h . docStream opts
+
+renderPrettyCodeDefault :: PrettyCode c => c -> Text
+renderPrettyCodeDefault = renderStrict . docStream defaultOptions
+
+renderPrettyCode :: PrettyCode c => Options -> c -> Text
+renderPrettyCode opts = renderStrict . docStream opts
+
+docStream :: PrettyCode c => Options -> c -> SimpleDocStream Ann
+docStream opts =
+  layoutPretty defaultLayoutOptions
+    . run
+    . runReader opts
+    . ppCode


### PR DESCRIPTION
This adds `ansi-terminal` dependency to the Main target but this is
already a transitive dependency of `prettyprinter-ansi-terminal`.

We want to add this support globally which we will do in https://github.com/heliaxdev/minijuvix/issues/38.