### PR TITLE
[minihaskell] Do not add id suffix to top-level modules and main

### DIFF
--- a/src/MiniJuvix/Translation/MicroJuvixToMiniHaskell.hs
+++ b/src/MiniJuvix/Translation/MicroJuvixToMiniHaskell.hs
@@ -86,7 +86,7 @@ goName n =
 
 goNameText :: Name -> Text
 goNameText n =
-  adaptFirstLetter lexeme <> "_" <> show (n ^. nameId . unNameId)
+  adaptFirstLetter lexeme <> nameTextSuffix
   where
     lexeme
       | Text.null lexeme' = "v"
@@ -110,6 +110,16 @@ goNameText n =
           KNameTopModule -> True
           KNameLocalModule -> True
           _ -> False
+    nameTextSuffix :: Text
+    nameTextSuffix = case n ^. nameKind of
+      KNameTopModule -> mempty
+      KNameFunction ->
+        if n ^. nameText == haskellMainName then mempty else idSuffix
+      _ -> idSuffix
+    idSuffix :: Text
+    idSuffix = "_" <> show (n ^. nameId . unNameId)
+    haskellMainName :: Text
+    haskellMainName = "main"
 
 goFunctionDef :: Members '[Error Err, Reader InfoTable] r => FunctionDef -> Sem r H.FunctionDef
 goFunctionDef FunctionDef {..} = do


### PR DESCRIPTION
For minihaskell the name of the output file needs to match the module
name. So we must not add the usual '_<nameid>' suffix to top level
names.

Additionally the main function in a haskell file is the entry-point to
the haskell program. So the suffix must not be added in this case also.