### PR TITLE
Make the `--show-name-ids` flag global

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -402,14 +402,21 @@ runCLI cli = do
     Termination (CallGraph o@CallGraphOptions {..}) -> do
       a <- head . (^. Abstract.resultModules) <$> runIO (upToAbstract (getEntryPoint root o))
       let callMap = T.buildCallMap a
-          opts' = Abstract.defaultOptions
+          opts' =
+            Abstract.defaultOptions
+              { Abstract._optShowNameId = globalOptions ^. globalShowNameIds
+              }
           completeGraph = T.completeCallGraph callMap
           filteredGraph = maybe completeGraph (`T.unsafeFilterGraph` completeGraph) _graphFunctionNameFilter
           recBehav = map T.recursiveBehaviour (T.reflexiveEdges filteredGraph)
       renderStdOutAbs (Abstract.ppOut opts' filteredGraph)
       putStrLn ""
       forM_ recBehav $ \r -> do
-        let n = toAnsiText' (Scoper.ppOutDefault (A._recBehaviourFunction r))
+        let sopts =
+              Scoper.defaultOptions
+                { Scoper._optShowNameId = globalOptions ^. globalShowNameIds
+                }
+            n = toAnsiText' (Scoper.ppOut sopts (A._recBehaviourFunction r))
         renderStdOutAbs (Abstract.ppOut opts' r)
         putStrLn ""
         case T.findOrder r of

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -14,7 +14,6 @@ import MiniJuvix.Pipeline
 import MiniJuvix.Prelude hiding (Doc)
 import MiniJuvix.Prelude.Pretty hiding (Doc)
 import MiniJuvix.Syntax.Abstract.Pretty qualified as Abstract
-import MiniJuvix.Syntax.Abstract.Pretty.Ansi qualified as A
 import MiniJuvix.Syntax.Concrete.Language qualified as M
 import MiniJuvix.Syntax.Concrete.Parser qualified as Parser
 import MiniJuvix.Syntax.Concrete.Scoped.Highlight qualified as Scoper
@@ -39,8 +38,9 @@ import Text.Show.Pretty hiding (Html)
 
 --------------------------------------------------------------------------------
 
-newtype GlobalOptions = GlobalOptions
-  { _globalNoColors :: Bool
+data GlobalOptions = GlobalOptions
+  { _globalNoColors :: Bool,
+    _globalShowNameIds :: Bool
   }
 
 data Command
@@ -61,7 +61,6 @@ data CLI = CLI
 
 data ScopeOptions = ScopeOptions
   { _scopeInputFiles :: NonEmpty FilePath,
-    _scopeShowIds :: Bool,
     _scopeInlineImports :: Bool
   }
 
@@ -89,6 +88,11 @@ parseGlobalOptions = do
     switch
       ( long "no-colors"
           <> help "Disable globally ANSI formatting "
+      )
+  _globalShowNameIds <-
+    switch
+      ( long "show-name-ids"
+          <> help "Show the unique number of each identifier when pretty printing"
       )
   pure GlobalOptions {..}
 
@@ -148,11 +152,6 @@ parseScope = do
             <> help "Path to one ore more MiniJuvix files"
             <> action "file"
         )
-  _scopeShowIds <-
-    switch
-      ( long "show-name-ids"
-          <> help "Show the unique number of each identifier"
-      )
   _scopeInlineImports <-
     switch
       ( long "inline-imports"
@@ -272,10 +271,10 @@ parseCommand =
             (Termination <$> parseTerminationCommand)
             (progDesc "Subcommands related to termination checking")
 
-mkScopePrettyOptions :: ScopeOptions -> Scoper.Options
-mkScopePrettyOptions ScopeOptions {..} =
+mkScopePrettyOptions :: GlobalOptions -> ScopeOptions -> Scoper.Options
+mkScopePrettyOptions g ScopeOptions {..} =
   Scoper.defaultOptions
-    { Scoper._optShowNameId = _scopeShowIds,
+    { Scoper._optShowNameId = g ^. globalShowNameIds,
       Scoper._optInlineImports = _scopeInlineImports
     }
 
@@ -338,19 +337,25 @@ instance HasEntryPoint CallGraphOptions where
 
 runCLI :: CLI -> IO ()
 runCLI cli = do
-  let useColors = not (cli ^. (cliGlobalOptions . globalNoColors))
-      renderIO' :: forall a. (HasAnsiBackend a, HasTextBackend a) => a -> IO ()
-      renderIO' = renderIO useColors
+  supportsAnsiStdOut <- Ansi.hSupportsANSI IO.stdout
+  let globalOptions = cli ^. cliGlobalOptions
+      useColors = not (globalOptions ^. globalNoColors)
       toAnsiText' :: forall a. (HasAnsiBackend a, HasTextBackend a) => a -> Text
       toAnsiText' = toAnsiText useColors
+      -- Note: Probably a GHC bug specialises renderStdOut to the type
+      -- of the arugment for its first usage in the rest of the do block .
+      renderStdOut :: (HasAnsiBackend a, HasTextBackend a) => a -> IO ()
+      renderStdOut = renderIO (supportsAnsiStdOut && useColors)
+      renderStdOutAbs :: Abstract.PPOutput -> IO ()
+      renderStdOutAbs = renderStdOut
+      renderStdOutMini :: MiniHaskell.PPOutput -> IO ()
+      renderStdOutMini = renderStdOut
+      renderStdOutMicro :: Micro.PPOutput -> IO ()
+      renderStdOutMicro = renderStdOut
   root <- findRoot
   case cli ^. cliCommand of
     DisplayVersion -> runDisplayVersion
     DisplayRoot -> putStrLn (pack root)
-    Scope opts -> do
-      l <- (^. Scoper.resultModules) <$> runIO (upToScoping (getEntryPoint root opts))
-      forM_ l $ \s -> do
-        renderIO' (Scoper.ppOut' (mkScopePrettyOptions opts) s)
     Highlight o -> do
       let entry :: EntryPoint
           entry = getEntryPoint root o
@@ -362,13 +367,21 @@ runCLI cli = do
     Parse ParseOptions {..} -> do
       m <- parseModuleIO _parseInputFile
       if _parseNoPrettyShow then print m else pPrint m
+    Scope opts -> do
+      l <- (^. Scoper.resultModules) <$> runIO (upToScoping (getEntryPoint root opts))
+      forM_ l $ \s -> do
+        renderStdOut (Scoper.ppOut (mkScopePrettyOptions globalOptions opts) s)
     Html o@HtmlOptions {..} -> do
       res <- runIO (upToScoping (getEntryPoint root o))
       let m = head (res ^. Scoper.resultModules)
       genHtml Scoper.defaultOptions _htmlRecursive _htmlTheme m
     MicroJuvix (Pretty opts) -> do
       micro <- head . (^. Micro.resultModules) <$> runIO (upToMicroJuvix (getEntryPoint root opts))
-      renderIO' (Micro.ppOut micro)
+      let ppOpts =
+            Micro.defaultOptions
+              { Micro._optShowNameId = globalOptions ^. globalShowNameIds
+              }
+      renderStdOutMicro (Micro.ppOut ppOpts micro)
     MicroJuvix (TypeCheck opts) -> do
       micro <- head . (^. MicroTyped.resultModules) <$> runIO (upToMicroJuvixTyped (getEntryPoint root opts))
       case MicroTyped.checkModule micro of
@@ -376,9 +389,7 @@ runCLI cli = do
         Left err -> printErrorAnsi err >> exitFailure
     MiniHaskell o -> do
       minihaskell <- head . (^. MiniHaskell.resultModules) <$> runIO (upToMiniHaskell (getEntryPoint root o))
-      supportsAnsi <- Ansi.hSupportsANSI IO.stdout
-      -- TODO fix #38
-      renderIO (supportsAnsi && useColors) (MiniHaskell.ppOut minihaskell)
+      renderStdOutMini (MiniHaskell.ppOutDefault minihaskell)
     Termination (Calls opts@CallsOptions {..}) -> do
       a <- head . (^. Abstract.resultModules) <$> runIO (upToAbstract (getEntryPoint root opts))
       let callMap0 = T.buildCallMap a
@@ -386,20 +397,20 @@ runCLI cli = do
             Nothing -> callMap0
             Just f -> T.filterCallMap f callMap0
           opts' = T.callsPrettyOptions opts
-      A.printPrettyCode opts' callMap
+      renderStdOutAbs (Abstract.ppOut opts' callMap)
       putStrLn ""
     Termination (CallGraph o@CallGraphOptions {..}) -> do
       a <- head . (^. Abstract.resultModules) <$> runIO (upToAbstract (getEntryPoint root o))
       let callMap = T.buildCallMap a
-          opts' = A.defaultOptions
+          opts' = Abstract.defaultOptions
           completeGraph = T.completeCallGraph callMap
           filteredGraph = maybe completeGraph (`T.unsafeFilterGraph` completeGraph) _graphFunctionNameFilter
           recBehav = map T.recursiveBehaviour (T.reflexiveEdges filteredGraph)
-      A.printPrettyCode opts' filteredGraph
+      renderStdOutAbs (Abstract.ppOut opts' filteredGraph)
       putStrLn ""
       forM_ recBehav $ \r -> do
-        let n = toAnsiText' (Scoper.ppOut (A._recBehaviourFunction r))
-        renderIO useColors (Abstract.ppOut r)
+        let n = toAnsiText' (Scoper.ppOutDefault (A._recBehaviourFunction r))
+        renderStdOutAbs (Abstract.ppOut opts' r)
         putStrLn ""
         case T.findOrder r of
           Nothing -> putStrLn (n <> " Fails the termination checking")

--- a/src/MiniJuvix/Pipeline.hs
+++ b/src/MiniJuvix/Pipeline.hs
@@ -6,7 +6,6 @@ module MiniJuvix.Pipeline
 where
 
 import Data.Kind qualified as GHC
-import GHC.IO.Exception
 import MiniJuvix.Pipeline.EntryPoint
 import MiniJuvix.Pipeline.Stage
 import MiniJuvix.Prelude
@@ -45,7 +44,7 @@ runIO = runIOEither >=> mayThrow
   where
     mayThrow :: Either AJuvixError r -> IO r
     mayThrow = \case
-      Left r -> printErrorAnsi r >> ioError (userError "")
+      Left err -> printErrorAnsi err >> exitFailure
       Right r -> return r
 
 --------------------------------------------------------------------------------

--- a/src/MiniJuvix/Prelude/Error.hs
+++ b/src/MiniJuvix/Prelude/Error.hs
@@ -9,11 +9,11 @@ data AJuvixError = forall e. JuvixError e => AJuvixError e
 
 -- | Minimal interface of an minijuvix error.
 class Typeable e => JuvixError e where
-  -- | Print the to stderr with Ansi formatting.
+  -- | Print the error to stderr with Ansi formatting.
   printErrorAnsi :: e -> IO ()
   printErrorAnsi = hPutStrLn stderr . renderAnsiText
 
-  -- | Print the to stderr without formatting.
+  -- | Print the error to stderr without formatting.
   printErrorText :: e -> IO ()
   printErrorText = hPutStrLn stderr . renderText
 
@@ -22,7 +22,6 @@ class Typeable e => JuvixError e where
 
   -- | Render the error with Ansi formatting (if any).
   renderAnsiText :: e -> Text
-  renderAnsiText = renderText
 
 toAJuvixError :: JuvixError e => e -> AJuvixError
 toAJuvixError = AJuvixError
@@ -44,6 +43,10 @@ runErrorIO =
 
 instance JuvixError Text where
   renderText = id
+  renderAnsiText = id
 
 instance JuvixError AJuvixError where
   renderText (AJuvixError r) = renderText r
+  renderAnsiText (AJuvixError r) = renderAnsiText r
+  printErrorAnsi (AJuvixError r) = printErrorAnsi r
+  printErrorText (AJuvixError r) = printErrorText r

--- a/src/MiniJuvix/Prelude/Pretty.hs
+++ b/src/MiniJuvix/Prelude/Pretty.hs
@@ -19,8 +19,8 @@ renderIO :: (HasAnsiBackend a, HasTextBackend a) => Bool -> a -> IO ()
 renderIO useColors = hRenderIO useColors stdout
 
 hRenderIO :: (HasAnsiBackend a, HasTextBackend a) => Bool -> Handle -> a -> IO ()
-hRenderIO b h
-  | b = Ansi.renderIO h . toAnsi
+hRenderIO useColors h
+  | useColors = Ansi.renderIO h . toAnsi
   | otherwise = Text.renderIO h . toText
 
 toAnsiText :: (HasAnsiBackend a, HasTextBackend a) => Bool -> a -> Text

--- a/src/MiniJuvix/Syntax/Abstract/Pretty.hs
+++ b/src/MiniJuvix/Syntax/Abstract/Pretty.hs
@@ -1,17 +1,22 @@
-module MiniJuvix.Syntax.Abstract.Pretty where
+module MiniJuvix.Syntax.Abstract.Pretty
+  ( module MiniJuvix.Syntax.Abstract.Pretty,
+    module MiniJuvix.Syntax.Abstract.Pretty.Options,
+  )
+where
 
 import MiniJuvix.Prelude
 import MiniJuvix.Prelude.Pretty
 import MiniJuvix.Syntax.Abstract.Pretty.Ansi qualified as Ansi
 import MiniJuvix.Syntax.Abstract.Pretty.Base
+import MiniJuvix.Syntax.Abstract.Pretty.Options
 
 newtype PPOutput = PPOutput (SimpleDocStream Ann)
 
-ppOut :: PrettyCode c => c -> PPOutput
-ppOut = PPOutput . docStream defaultOptions
+ppOutDefault :: PrettyCode c => c -> PPOutput
+ppOutDefault = PPOutput . docStream defaultOptions
 
-ppOut' :: PrettyCode c => Options -> c -> PPOutput
-ppOut' o = PPOutput . docStream o
+ppOut :: PrettyCode c => Options -> c -> PPOutput
+ppOut o = PPOutput . docStream o
 
 instance HasAnsiBackend PPOutput where
   toAnsi (PPOutput o) = reAnnotateS Ansi.stylize o

--- a/src/MiniJuvix/Syntax/Abstract/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/Abstract/Pretty/Base.hs
@@ -1,6 +1,7 @@
 module MiniJuvix.Syntax.Abstract.Pretty.Base
   ( module MiniJuvix.Syntax.Abstract.Pretty.Base,
     module MiniJuvix.Syntax.Abstract.Pretty.Ann,
+    module MiniJuvix.Syntax.Abstract.Pretty.Options,
   )
 where
 
@@ -8,19 +9,12 @@ import MiniJuvix.Internal.Strings qualified as Str
 import MiniJuvix.Prelude
 import MiniJuvix.Syntax.Abstract.Language
 import MiniJuvix.Syntax.Abstract.Pretty.Ann
+import MiniJuvix.Syntax.Abstract.Pretty.Options
 import MiniJuvix.Syntax.Concrete.Scoped.Pretty.Base qualified as S
 import MiniJuvix.Syntax.Fixity
 import MiniJuvix.Syntax.Universe
 import MiniJuvix.Syntax.Usage
 import Prettyprinter
-
-data Options = Options
-  { _optShowNameId :: Bool,
-    _optIndent :: Int,
-    _optShowDecreasingArgs :: ShowDecrArgs
-  }
-
-data ShowDecrArgs = OnlyArg | OnlyRel | ArgRel
 
 docStream :: PrettyCode c => Options -> c -> SimpleDocStream Ann
 docStream opts =
@@ -43,14 +37,6 @@ ppSCode :: (Members '[Reader Options] r, S.PrettyCode c) => c -> Sem r (Doc Ann)
 ppSCode c = do
   opts <- asks toSOptions
   return $ alterAnnotations (maybeToList . fromScopedAnn) (S.runPrettyCode opts c)
-
-defaultOptions :: Options
-defaultOptions =
-  Options
-    { _optShowNameId = False,
-      _optIndent = 2,
-      _optShowDecreasingArgs = OnlyRel
-    }
 
 ppDefault :: PrettyCode c => c -> Doc Ann
 ppDefault = runPrettyCode defaultOptions

--- a/src/MiniJuvix/Syntax/Abstract/Pretty/Options.hs
+++ b/src/MiniJuvix/Syntax/Abstract/Pretty/Options.hs
@@ -1,0 +1,21 @@
+module MiniJuvix.Syntax.Abstract.Pretty.Options where
+
+import MiniJuvix.Prelude
+
+data Options = Options
+  { _optShowNameId :: Bool,
+    _optIndent :: Int,
+    _optShowDecreasingArgs :: ShowDecrArgs
+  }
+
+data ShowDecrArgs = OnlyArg | OnlyRel | ArgRel
+
+defaultOptions :: Options
+defaultOptions =
+  Options
+    { _optShowNameId = False,
+      _optIndent = 2,
+      _optShowDecreasingArgs = OnlyRel
+    }
+
+makeLenses ''Options

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Pretty.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Pretty.hs
@@ -1,26 +1,23 @@
 module MiniJuvix.Syntax.Concrete.Scoped.Pretty
   ( module MiniJuvix.Syntax.Concrete.Scoped.Pretty,
-    module MiniJuvix.Syntax.Concrete.Scoped.Pretty.Base,
+    module MiniJuvix.Syntax.Concrete.Scoped.Pretty.Options,
   )
 where
-
-------------------------------------------------------------------------------
 
 import MiniJuvix.Prelude
 import MiniJuvix.Prelude.Pretty
 import MiniJuvix.Syntax.Concrete.Scoped.Pretty.Ann
 import MiniJuvix.Syntax.Concrete.Scoped.Pretty.Ansi qualified as Ansi
 import MiniJuvix.Syntax.Concrete.Scoped.Pretty.Base
-
-------------------------------------------------------------------------------
+import MiniJuvix.Syntax.Concrete.Scoped.Pretty.Options
 
 newtype PPOutput = PPOutput (SimpleDocStream Ann)
 
-ppOut :: PrettyCode c => c -> PPOutput
-ppOut = PPOutput . docStream defaultOptions
+ppOutDefault :: PrettyCode c => c -> PPOutput
+ppOutDefault = PPOutput . docStream defaultOptions
 
-ppOut' :: PrettyCode c => Options -> c -> PPOutput
-ppOut' o = PPOutput . docStream o
+ppOut :: PrettyCode c => Options -> c -> PPOutput
+ppOut o = PPOutput . docStream o
 
 instance HasAnsiBackend PPOutput where
   toAnsi (PPOutput o) = reAnnotateS Ansi.stylize o

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Pretty/Base.hs
@@ -1,6 +1,7 @@
 module MiniJuvix.Syntax.Concrete.Scoped.Pretty.Base
   ( module MiniJuvix.Syntax.Concrete.Scoped.Pretty.Base,
     module MiniJuvix.Syntax.Concrete.Scoped.Pretty.Ann,
+    module MiniJuvix.Syntax.Concrete.Scoped.Pretty.Options,
   )
 where
 
@@ -11,6 +12,7 @@ import MiniJuvix.Syntax.Concrete.Language
 import MiniJuvix.Syntax.Concrete.Scoped.Name (AbsModulePath)
 import MiniJuvix.Syntax.Concrete.Scoped.Name qualified as S
 import MiniJuvix.Syntax.Concrete.Scoped.Pretty.Ann
+import MiniJuvix.Syntax.Concrete.Scoped.Pretty.Options
 import Prettyprinter hiding (braces, parens)
 
 docStream :: PrettyCode c => Options -> c -> SimpleDocStream Ann
@@ -19,20 +21,6 @@ docStream opts =
     . run
     . runReader opts
     . ppCode
-
-data Options = Options
-  { _optShowNameId :: Bool,
-    _optInlineImports :: Bool,
-    _optIndent :: Int
-  }
-
-defaultOptions :: Options
-defaultOptions =
-  Options
-    { _optShowNameId = False,
-      _optInlineImports = False,
-      _optIndent = 2
-    }
 
 class PrettyCode a where
   ppCode :: Members '[Reader Options] r => a -> Sem r (Doc Ann)

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Pretty/Options.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Pretty/Options.hs
@@ -1,0 +1,19 @@
+module MiniJuvix.Syntax.Concrete.Scoped.Pretty.Options where
+
+import MiniJuvix.Prelude
+
+data Options = Options
+  { _optShowNameId :: Bool,
+    _optInlineImports :: Bool,
+    _optIndent :: Int
+  }
+
+defaultOptions :: Options
+defaultOptions =
+  Options
+    { _optShowNameId = False,
+      _optInlineImports = False,
+      _optIndent = 2
+    }
+
+makeLenses ''Options

--- a/src/MiniJuvix/Syntax/MicroJuvix/Error/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Error/Pretty/Base.hs
@@ -4,16 +4,16 @@ import MiniJuvix.Prelude
 import MiniJuvix.Syntax.Concrete.Language (getLoc)
 import MiniJuvix.Syntax.MicroJuvix.Error.Types
 import MiniJuvix.Syntax.MicroJuvix.Language
-import MiniJuvix.Syntax.MicroJuvix.Pretty.Ann qualified as M
-import MiniJuvix.Syntax.MicroJuvix.Pretty.Base qualified as M
+import MiniJuvix.Syntax.MicroJuvix.Pretty.Ann qualified as Micro
+import MiniJuvix.Syntax.MicroJuvix.Pretty.Base qualified as Micro
 import Prettyprinter
 
 data Eann
   = Highlight
-  | MicroAnn M.Ann
+  | MicroAnn Micro.Ann
 
-ppCode :: M.PrettyCode c => c -> Doc Eann
-ppCode = reAnnotate MicroAnn . M.runPrettyCode M.defaultOptions
+ppCode :: Micro.PrettyCode c => c -> Doc Eann
+ppCode = reAnnotate MicroAnn . Micro.runPrettyCode Micro.defaultOptions
 
 indent' :: Doc ann -> Doc ann
 indent' = indent 2

--- a/src/MiniJuvix/Syntax/MicroJuvix/Pretty.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Pretty.hs
@@ -1,18 +1,23 @@
-module MiniJuvix.Syntax.MicroJuvix.Pretty where
+module MiniJuvix.Syntax.MicroJuvix.Pretty
+  ( module MiniJuvix.Syntax.MicroJuvix.Pretty,
+    module MiniJuvix.Syntax.MicroJuvix.Pretty.Options,
+  )
+where
 
 import MiniJuvix.Prelude
 import MiniJuvix.Prelude.Pretty
 import MiniJuvix.Syntax.MicroJuvix.Pretty.Ann
 import MiniJuvix.Syntax.MicroJuvix.Pretty.Ansi qualified as Ansi
 import MiniJuvix.Syntax.MicroJuvix.Pretty.Base
+import MiniJuvix.Syntax.MicroJuvix.Pretty.Options
 
 newtype PPOutput = PPOutput (SimpleDocStream Ann)
 
-ppOut :: PrettyCode c => c -> PPOutput
-ppOut = PPOutput . docStream defaultOptions
+ppOutDefault :: PrettyCode c => c -> PPOutput
+ppOutDefault = PPOutput . docStream defaultOptions
 
-ppOut' :: PrettyCode c => Options -> c -> PPOutput
-ppOut' o = PPOutput . docStream o
+ppOut :: PrettyCode c => Options -> c -> PPOutput
+ppOut o = PPOutput . docStream o
 
 instance HasAnsiBackend PPOutput where
   toAnsi (PPOutput o) = reAnnotateS Ansi.stylize o

--- a/src/MiniJuvix/Syntax/MicroJuvix/Pretty/Ansi.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Pretty/Ansi.hs
@@ -2,7 +2,6 @@ module MiniJuvix.Syntax.MicroJuvix.Pretty.Ansi where
 
 import MiniJuvix.Prelude
 import MiniJuvix.Syntax.MicroJuvix.Language
-import MiniJuvix.Syntax.MicroJuvix.Pretty.Ann
 import MiniJuvix.Syntax.MicroJuvix.Pretty.Base
 import Prettyprinter
 import Prettyprinter.Render.Terminal

--- a/src/MiniJuvix/Syntax/MicroJuvix/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Pretty/Base.hs
@@ -1,4 +1,9 @@
-module MiniJuvix.Syntax.MicroJuvix.Pretty.Base where
+module MiniJuvix.Syntax.MicroJuvix.Pretty.Base
+  ( module MiniJuvix.Syntax.MicroJuvix.Pretty.Base,
+    module MiniJuvix.Syntax.MicroJuvix.Pretty.Ann,
+    module MiniJuvix.Syntax.MicroJuvix.Pretty.Options,
+  )
+where
 
 import MiniJuvix.Internal.Strings qualified as Str
 import MiniJuvix.Prelude
@@ -7,19 +12,8 @@ import MiniJuvix.Syntax.Fixity
 import MiniJuvix.Syntax.ForeignBlock
 import MiniJuvix.Syntax.MicroJuvix.Language
 import MiniJuvix.Syntax.MicroJuvix.Pretty.Ann
+import MiniJuvix.Syntax.MicroJuvix.Pretty.Options
 import Prettyprinter
-
-data Options = Options
-  { _optIndent :: Int,
-    _optShowNameId :: Bool
-  }
-
-defaultOptions :: Options
-defaultOptions =
-  Options
-    { _optIndent = 2,
-      _optShowNameId = True
-    }
 
 docStream :: PrettyCode c => Options -> c -> SimpleDocStream Ann
 docStream opts =

--- a/src/MiniJuvix/Syntax/MicroJuvix/Pretty/Options.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Pretty/Options.hs
@@ -1,0 +1,17 @@
+module MiniJuvix.Syntax.MicroJuvix.Pretty.Options where
+
+import MiniJuvix.Prelude
+
+data Options = Options
+  { _optIndent :: Int,
+    _optShowNameId :: Bool
+  }
+
+defaultOptions :: Options
+defaultOptions =
+  Options
+    { _optIndent = 2,
+      _optShowNameId = True
+    }
+
+makeLenses ''Options

--- a/src/MiniJuvix/Syntax/MiniHaskell/Pretty.hs
+++ b/src/MiniJuvix/Syntax/MiniHaskell/Pretty.hs
@@ -1,17 +1,22 @@
-module MiniJuvix.Syntax.MiniHaskell.Pretty where
+module MiniJuvix.Syntax.MiniHaskell.Pretty
+  ( module MiniJuvix.Syntax.MiniHaskell.Pretty,
+    module MiniJuvix.Syntax.MiniHaskell.Pretty.Options,
+  )
+where
 
 import MiniJuvix.Prelude
 import MiniJuvix.Prelude.Pretty
 import MiniJuvix.Syntax.MiniHaskell.Pretty.Ansi qualified as Ansi
 import MiniJuvix.Syntax.MiniHaskell.Pretty.Base
+import MiniJuvix.Syntax.MiniHaskell.Pretty.Options
 
 newtype PPOutput = PPOutput (SimpleDocStream Ann)
 
-ppOut :: PrettyCode c => c -> PPOutput
-ppOut = PPOutput . docStream defaultOptions
+ppOutDefault :: PrettyCode c => c -> PPOutput
+ppOutDefault = PPOutput . docStream defaultOptions
 
-ppOut' :: PrettyCode c => Options -> c -> PPOutput
-ppOut' o = PPOutput . docStream o
+ppOut :: PrettyCode c => Options -> c -> PPOutput
+ppOut o = PPOutput . docStream o
 
 instance HasAnsiBackend PPOutput where
   toAnsi (PPOutput o) = reAnnotateS Ansi.stylize o

--- a/src/MiniJuvix/Syntax/MiniHaskell/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/MiniHaskell/Pretty/Base.hs
@@ -1,6 +1,7 @@
 module MiniJuvix.Syntax.MiniHaskell.Pretty.Base
   ( module MiniJuvix.Syntax.MiniHaskell.Pretty.Base,
     module MiniJuvix.Syntax.MiniHaskell.Pretty.Ann,
+    module MiniJuvix.Syntax.MiniHaskell.Pretty.Options,
   )
 where
 
@@ -10,17 +11,8 @@ import MiniJuvix.Syntax.Concrete.Language (Literal (..), LiteralLoc (..))
 import MiniJuvix.Syntax.Fixity
 import MiniJuvix.Syntax.MiniHaskell.Language
 import MiniJuvix.Syntax.MiniHaskell.Pretty.Ann
+import MiniJuvix.Syntax.MiniHaskell.Pretty.Options
 import Prettyprinter
-
-newtype Options = Options
-  { _optIndent :: Int
-  }
-
-defaultOptions :: Options
-defaultOptions =
-  Options
-    { _optIndent = 2
-    }
 
 docStream :: PrettyCode c => Options -> c -> SimpleDocStream Ann
 docStream opts =

--- a/src/MiniJuvix/Syntax/MiniHaskell/Pretty/Options.hs
+++ b/src/MiniJuvix/Syntax/MiniHaskell/Pretty/Options.hs
@@ -1,0 +1,15 @@
+module MiniJuvix.Syntax.MiniHaskell.Pretty.Options where
+
+import MiniJuvix.Prelude
+
+newtype Options = Options
+  { _optIndent :: Int
+  }
+
+defaultOptions :: Options
+defaultOptions =
+  Options
+    { _optIndent = 2
+    }
+
+makeLenses ''Options

--- a/src/MiniJuvix/Syntax/MonoJuvix/Pretty.hs
+++ b/src/MiniJuvix/Syntax/MonoJuvix/Pretty.hs
@@ -1,10 +1,15 @@
-module MiniJuvix.Syntax.MonoJuvix.Pretty where
+module MiniJuvix.Syntax.MonoJuvix.Pretty
+  ( module MiniJuvix.Syntax.MonoJuvix.Pretty,
+    module MiniJuvix.Syntax.MonoJuvix.Pretty.Options,
+  )
+where
 
 import MiniJuvix.Prelude
 import MiniJuvix.Prelude.Pretty
 import MiniJuvix.Syntax.MonoJuvix.Pretty.Ann
 import MiniJuvix.Syntax.MonoJuvix.Pretty.Ansi qualified as Ansi
 import MiniJuvix.Syntax.MonoJuvix.Pretty.Base
+import MiniJuvix.Syntax.MonoJuvix.Pretty.Options
 
 newtype PPOutput = PPOutput (SimpleDocStream Ann)
 

--- a/src/MiniJuvix/Syntax/MonoJuvix/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/MonoJuvix/Pretty/Base.hs
@@ -1,4 +1,8 @@
-module MiniJuvix.Syntax.MonoJuvix.Pretty.Base where
+module MiniJuvix.Syntax.MonoJuvix.Pretty.Base
+  ( module MiniJuvix.Syntax.MonoJuvix.Pretty.Base,
+    module MiniJuvix.Syntax.MonoJuvix.Pretty.Options,
+  )
+where
 
 import MiniJuvix.Internal.Strings qualified as Str
 import MiniJuvix.Prelude
@@ -7,17 +11,8 @@ import MiniJuvix.Syntax.Fixity
 import MiniJuvix.Syntax.ForeignBlock
 import MiniJuvix.Syntax.MonoJuvix.Language
 import MiniJuvix.Syntax.MonoJuvix.Pretty.Ann
+import MiniJuvix.Syntax.MonoJuvix.Pretty.Options
 import Prettyprinter
-
-newtype Options = Options
-  { _optIndent :: Int
-  }
-
-defaultOptions :: Options
-defaultOptions =
-  Options
-    { _optIndent = 2
-    }
 
 docStream :: PrettyCode c => Options -> c -> SimpleDocStream Ann
 docStream opts =

--- a/src/MiniJuvix/Syntax/MonoJuvix/Pretty/Options.hs
+++ b/src/MiniJuvix/Syntax/MonoJuvix/Pretty/Options.hs
@@ -1,0 +1,15 @@
+module MiniJuvix.Syntax.MonoJuvix.Pretty.Options where
+
+import MiniJuvix.Prelude
+
+newtype Options = Options
+  { _optIndent :: Int
+  }
+
+defaultOptions :: Options
+defaultOptions =
+  Options
+    { _optIndent = 2
+    }
+
+makeLenses ''Options


### PR DESCRIPTION
This PR makes the flag `--show-name-ids` global. This is probably a good idea since this flag is relevant in multiple commands.
Additionally, the `Options` record for each of the languages now has its own module. 