### PR TITLE
Add support for compile (by Jonathan)

### DIFF
--- a/src/MiniJuvix/Syntax/Abstract/InfoTable.hs
+++ b/src/MiniJuvix/Syntax/Abstract/InfoTable.hs
@@ -2,6 +2,7 @@ module MiniJuvix.Syntax.Abstract.InfoTable where
 
 import MiniJuvix.Prelude
 import MiniJuvix.Syntax.Abstract.Language
+import MiniJuvix.Syntax.Concrete.Scoped.Name qualified as S
 
 newtype FunctionInfo = FunctionInfo
   { _functionInfoDef :: FunctionDef
@@ -12,9 +13,8 @@ data ConstructorInfo = ConstructorInfo
     _constructorInfoType :: Expression
   }
 
-data AxiomInfo = AxiomInfo
-  { _axiomInfoType :: Expression,
-    _axiomInfoBackends :: [BackendItem]
+newtype AxiomInfo = AxiomInfo
+  { _axiomInfoType :: Expression
   }
 
 newtype InductiveInfo = InductiveInfo
@@ -25,7 +25,8 @@ data InfoTable = InfoTable
   { _infoConstructors :: HashMap ConstructorRef ConstructorInfo,
     _infoAxioms :: HashMap AxiomRef AxiomInfo,
     _infoInductives :: HashMap InductiveRef InductiveInfo,
-    _infoFunctions :: HashMap FunctionRef FunctionInfo
+    _infoFunctions :: HashMap FunctionRef FunctionInfo,
+    _infoCompilationRules :: HashMap S.Symbol [BackendItem]
   }
 
 emptyInfoTable :: InfoTable
@@ -34,7 +35,8 @@ emptyInfoTable =
     { _infoConstructors = mempty,
       _infoAxioms = mempty,
       _infoInductives = mempty,
-      _infoFunctions = mempty
+      _infoFunctions = mempty,
+      _infoCompilationRules = mempty
     }
 
 makeLenses ''InfoTable

--- a/src/MiniJuvix/Syntax/Abstract/InfoTableBuilder.hs
+++ b/src/MiniJuvix/Syntax/Abstract/InfoTableBuilder.hs
@@ -15,6 +15,7 @@ data InfoTableBuilder m a where
   RegisterConstructor :: InductiveInfo -> InductiveConstructorDef -> InfoTableBuilder m ()
   RegisterInductive :: InductiveDef -> InfoTableBuilder m InductiveInfo
   RegisterFunction :: FunctionDef -> InfoTableBuilder m ()
+  RegisterCompile :: Compile -> InfoTableBuilder m ()
 
 makeSem ''InfoTableBuilder
 
@@ -36,8 +37,7 @@ toState = reinterpret $ \case
     let ref = AxiomRef (unqualifiedSymbol (d ^. axiomName))
         info =
           AxiomInfo
-            { _axiomInfoType = d ^. axiomType,
-              _axiomInfoBackends = d ^. axiomBackendItems
+            { _axiomInfoType = d ^. axiomType
             }
      in modify (over infoAxioms (HashMap.insert ref info))
   RegisterConstructor _constructorInfoInductive def ->
@@ -62,6 +62,10 @@ toState = reinterpret $ \case
             { ..
             }
      in modify (over infoFunctions (HashMap.insert ref info))
+  RegisterCompile c ->
+    let name = c ^. compileName
+        backends = c ^. compileBackendItems
+     in modify (over infoCompilationRules (HashMap.insert name backends))
 
 runInfoTableBuilder :: Sem (InfoTableBuilder ': r) a -> Sem r (InfoTable, a)
 runInfoTableBuilder = runState emptyInfoTable . toState

--- a/src/MiniJuvix/Syntax/Abstract/Language.hs
+++ b/src/MiniJuvix/Syntax/Abstract/Language.hs
@@ -52,6 +52,7 @@ data Statement
   | StatementForeign ForeignBlock
   | StatementLocalModule LocalModule
   | StatementAxiom AxiomDef
+  | StatementCompile Compile
   deriving stock (Eq, Show)
 
 data FunctionDef = FunctionDef
@@ -190,8 +191,13 @@ data InductiveConstructorDef = InductiveConstructorDef
 
 data AxiomDef = AxiomDef
   { _axiomName :: AxiomName,
-    _axiomType :: Expression,
-    _axiomBackendItems :: [BackendItem]
+    _axiomType :: Expression
+  }
+  deriving stock (Eq, Show)
+
+data Compile = Compile
+  { _compileName :: S.Symbol,
+    _compileBackendItems :: [BackendItem]
   }
   deriving stock (Eq, Show)
 
@@ -209,6 +215,7 @@ makeLenses ''ConstructorRef
 makeLenses ''InductiveRef
 makeLenses ''AxiomRef
 makeLenses ''AxiomDef
+makeLenses ''Compile
 
 idenName :: Iden -> Name
 idenName = \case

--- a/src/MiniJuvix/Syntax/Backends.hs
+++ b/src/MiniJuvix/Syntax/Backends.hs
@@ -3,12 +3,20 @@ module MiniJuvix.Syntax.Backends where
 import MiniJuvix.Prelude
 
 data Backend = BackendGhc | BackendAgda
-  deriving stock (Show, Eq, Ord)
+  deriving stock (Show, Eq, Ord, Generic)
+
+instance Hashable Backend
 
 data BackendItem = BackendItem
   { _backendItemBackend :: Backend,
     _backendItemCode :: Text
   }
-  deriving stock (Show, Eq, Ord)
+  deriving stock (Show, Ord, Eq, Generic)
+
+instance Hashable BackendItem
 
 makeLenses ''BackendItem
+
+isBackendSupported :: Backend -> Bool
+isBackendSupported BackendGhc = True
+isBackendSupported BackendAgda = False

--- a/src/MiniJuvix/Syntax/Concrete/Language.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Language.hs
@@ -105,6 +105,7 @@ data Statement (s :: Stage)
   | StatementEval (Eval s)
   | StatementPrint (Print s)
   | StatementForeign ForeignBlock
+  | StatementCompile (Compile s)
 
 deriving stock instance
   ( Show (ImportType s),
@@ -190,8 +191,7 @@ deriving stock instance (Ord (ExpressionType s), Ord (SymbolType s)) => Ord (Typ
 
 data AxiomDef (s :: Stage) = AxiomDef
   { _axiomName :: SymbolType s,
-    _axiomType :: ExpressionType s,
-    _axiomBackendItems :: [BackendItem]
+    _axiomType :: ExpressionType s
   }
 
 deriving stock instance (Show (ExpressionType s), Show (SymbolType s)) => Show (AxiomDef s)
@@ -1068,43 +1068,52 @@ deriving stock instance
   Ord (LetClause s)
 
 --------------------------------------------------------------------------------
+-- Compile statements
+--------------------------------------------------------------------------------
+
+data Compile s = Compile
+  { _compileName :: SymbolType s,
+    _compileBackendItems :: [BackendItem]
+  }
+
+deriving stock instance
+  (Show (SymbolType s)) => Show (Compile s)
+
+deriving stock instance
+  (Ord (SymbolType s)) => Ord (Compile s)
+
+deriving stock instance
+  (Eq (SymbolType s)) => Eq (Compile s)
+
+--------------------------------------------------------------------------------
 -- Debugging statements
 --------------------------------------------------------------------------------
 
 newtype Eval (s :: Stage) = Eval {evalExpression :: ExpressionType s}
 
 deriving stock instance
-  Show
-    (ExpressionType s) =>
-  Show (Eval s)
+  Show (ExpressionType s) => Show (Eval s)
 
 deriving stock instance
-  Eq
-    (ExpressionType s) =>
-  Eq (Eval s)
+  Eq (ExpressionType s) => Eq (Eval s)
 
 deriving stock instance
-  Ord
-    (ExpressionType s) =>
-  Ord (Eval s)
+  Ord (ExpressionType s) => Ord (Eval s)
+
+--------------------------------------------------------------------------------
 
 newtype Print (s :: Stage) = Print {printExpression :: ExpressionType s}
 
 deriving stock instance
-  Show
-    ( ExpressionType s
-    ) =>
-  Show (Print s)
+  Show (ExpressionType s) => Show (Print s)
 
 deriving stock instance
-  Eq
-    (ExpressionType s) =>
-  Eq (Print s)
+  Eq (ExpressionType s) => Eq (Print s)
 
 deriving stock instance
-  Ord
-    (ExpressionType s) =>
-  Ord (Print s)
+  Ord (ExpressionType s) => Ord (Print s)
+
+--------------------------------------------------------------------------------
 
 makeLenses ''InductiveDef
 makeLenses ''InductiveConstructorDef
@@ -1124,6 +1133,9 @@ makeLenses ''PatternApp
 makeLenses ''PatternInfixApp
 makeLenses ''PatternPostfixApp
 makeLenses ''LiteralLoc
+makeLenses ''Compile
+
+--------------------------------------------------------------------------------
 
 idenOverName :: (forall s. S.Name' s -> S.Name' s) -> ScopedIden -> ScopedIden
 idenOverName f = \case

--- a/src/MiniJuvix/Syntax/Concrete/Lexer.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Lexer.hs
@@ -134,6 +134,7 @@ allKeywords =
     kwColonOmega,
     kwColonOne,
     kwColonZero,
+    kwCompile,
     kwEnd,
     kwEval,
     kwForeign,
@@ -188,6 +189,9 @@ kwColonOne = keyword Str.colonOne
 
 kwColonZero :: Member InfoTableBuilder r => ParsecS r ()
 kwColonZero = keyword Str.colonZero
+
+kwCompile :: Member InfoTableBuilder r => ParsecS r ()
+kwCompile = keyword Str.compile
 
 kwEnd :: Member InfoTableBuilder r => ParsecS r ()
 kwEnd = keyword Str.end

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Error.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Error.hs
@@ -31,6 +31,11 @@ data ScopeError
   | ErrAmbiguousModuleSym AmbiguousModuleSym
   | ErrUnusedOperatorDef UnusedOperatorDef
   | ErrWrongTopModuleName WrongTopModuleName
+  | ErrWrongLocationCompileBlock WrongLocationCompileBlock
+  | ErrMultipleCompileBlockSameName MultipleCompileBlockSameName
+  | ErrMultipleCompileRuleSameBackend MultipleCompileRuleSameBackend
+  | ErrWrongKindExpressionCompileBlock WrongKindExpressionCompileBlock
+  | ErrUnsupportedBackend UnsupportedBackend
   deriving stock (Show)
 
 ppScopeError :: ScopeError -> Doc Eann
@@ -52,6 +57,11 @@ ppScopeError s = case s of
   ErrAmbiguousModuleSym e -> ppError e
   ErrUnusedOperatorDef e -> ppError e
   ErrLacksFunctionClause e -> ppError e
+  ErrWrongLocationCompileBlock e -> ppError e
+  ErrMultipleCompileBlockSameName e -> ppError e
+  ErrMultipleCompileRuleSameBackend e -> ppError e
+  ErrWrongKindExpressionCompileBlock e -> ppError e
+  ErrUnsupportedBackend e -> ppError e
 
 docStream :: ScopeError -> SimpleDocStream Eann
 docStream = layoutPretty defaultLayoutOptions . ppScopeError

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Error.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Error.hs
@@ -35,7 +35,6 @@ data ScopeError
   | ErrMultipleCompileBlockSameName MultipleCompileBlockSameName
   | ErrMultipleCompileRuleSameBackend MultipleCompileRuleSameBackend
   | ErrWrongKindExpressionCompileBlock WrongKindExpressionCompileBlock
-  | ErrUnsupportedBackend UnsupportedBackend
   deriving stock (Show)
 
 ppScopeError :: ScopeError -> Doc Eann
@@ -61,7 +60,6 @@ ppScopeError s = case s of
   ErrMultipleCompileBlockSameName e -> ppError e
   ErrMultipleCompileRuleSameBackend e -> ppError e
   ErrWrongKindExpressionCompileBlock e -> ppError e
-  ErrUnsupportedBackend e -> ppError e
 
 docStream :: ScopeError -> SimpleDocStream Eann
 docStream = layoutPretty defaultLayoutOptions . ppScopeError

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Error/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Error/Pretty/Base.hs
@@ -193,12 +193,6 @@ instance PrettyError WrongKindExpressionCompileBlock where
   ppError WrongKindExpressionCompileBlock {..} =
     "Unsupported expression kind for the symbol" <> ppCode _wrongKindExpressionCompileBlock
 
-instance PrettyError UnsupportedBackend where
-  ppError UnsupportedBackend {..} =
-    "Unsupported" <+> ppCode _unsupportedBackend <+> "backend"
-      <+> "used at"
-      <+> pretty (getLoc _unsupportedBackendSym)
-
 ambiguousMessage :: Name -> [SymbolEntry] -> Doc Eann
 ambiguousMessage n es =
   "The symbol" <+> ppCode n <+> "at" <+> pretty (getLoc n) <+> "is ambiguous." <> line

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Error/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Error/Pretty/Base.hs
@@ -161,6 +161,44 @@ instance PrettyError AmbiguousSym where
 instance PrettyError AmbiguousModuleSym where
   ppError AmbiguousModuleSym {..} = ambiguousMessage _ambiguousModName _ambiguousModSymEntires
 
+instance PrettyError WrongLocationCompileBlock where
+  ppError WrongLocationCompileBlock {..} =
+    let name = _wrongLocationCompileBlockName
+     in "The set of compilation rules for the symbol" <+> highlight (ppCode name)
+          <+> "at"
+          <+> pretty (getLoc name)
+          <> line
+          <> "need to be defined in the module:"
+          <> line
+          <> highlight (ppCode _wrongLocationCompileBlockExpectedModPath)
+          <> line
+
+instance PrettyError MultipleCompileBlockSameName where
+  ppError MultipleCompileBlockSameName {..} =
+    let name = _multipleCompileBlockSym
+     in "Multiple compile blocks for the symbol" <+> highlight (ppCode name)
+          <+> "at"
+          <+> pretty (getLoc name)
+
+instance PrettyError MultipleCompileRuleSameBackend where
+  ppError MultipleCompileRuleSameBackend {..} =
+    let backend = _backendItemBackend _multipleCompileRuleSameBackendBackendItem
+        name = _multipleCompileRuleSameBackendSym
+     in "Multiple" <+> highlight (ppCode backend) <+> "compilation rules for the symbol"
+          <+> highlight (ppCode name)
+          <+> "at"
+          <+> pretty (getLoc name)
+
+instance PrettyError WrongKindExpressionCompileBlock where
+  ppError WrongKindExpressionCompileBlock {..} =
+    "Unsupported expression kind for the symbol" <> ppCode _wrongKindExpressionCompileBlock
+
+instance PrettyError UnsupportedBackend where
+  ppError UnsupportedBackend {..} =
+    "Unsupported" <+> ppCode _unsupportedBackend <+> "backend"
+      <+> "used at"
+      <+> pretty (getLoc _unsupportedBackendSym)
+
 ambiguousMessage :: Name -> [SymbolEntry] -> Doc Eann
 ambiguousMessage n es =
   "The symbol" <+> ppCode n <+> "at" <+> pretty (getLoc n) <+> "is ambiguous." <> line

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Error/Types.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Error/Types.hs
@@ -105,3 +105,31 @@ data AmbiguousModuleSym = AmbiguousModuleSym
     _ambiguousModSymEntires :: [SymbolEntry]
   }
   deriving stock (Show)
+
+data WrongLocationCompileBlock = WrongLocationCompileBlock
+  { _wrongLocationCompileBlockExpectedModPath :: S.AbsModulePath,
+    _wrongLocationCompileBlockName :: Name
+  }
+  deriving stock (Show)
+
+newtype MultipleCompileBlockSameName = MultipleCompileBlockSameName
+  { _multipleCompileBlockSym :: Symbol
+  }
+  deriving stock (Show)
+
+data MultipleCompileRuleSameBackend = MultipleCompileRuleSameBackend
+  { _multipleCompileRuleSameBackendBackendItem :: BackendItem,
+    _multipleCompileRuleSameBackendSym :: Symbol
+  }
+  deriving stock (Show)
+
+newtype WrongKindExpressionCompileBlock = WrongKindExpressionCompileBlock
+  { _wrongKindExpressionCompileBlock :: SymbolEntry
+  }
+  deriving stock (Show)
+
+data UnsupportedBackend = UnsupportedBackend
+  { _unsupportedBackend :: Backend,
+    _unsupportedBackendSym :: Symbol
+  }
+  deriving stock (Show)

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/InfoTable.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/InfoTable.hs
@@ -14,14 +14,18 @@ newtype ConstructorInfo = ConstructorInfo
   }
   deriving stock (Eq, Show)
 
-data AxiomInfo = AxiomInfo
-  { _axiomInfoType :: Expression,
-    _axiomInfoBackends :: [BackendItem]
+newtype AxiomInfo = AxiomInfo
+  { _axiomInfoType :: Expression
   }
   deriving stock (Eq, Show)
 
 newtype InductiveInfo = InductiveInfo
   { _inductiveInfoDef :: InductiveDef 'Scoped
+  }
+  deriving stock (Eq, Show)
+
+newtype CompileInfo = CompileInfo
+  { _compileInfoBackendItems :: [BackendItem]
   }
   deriving stock (Eq, Show)
 
@@ -31,7 +35,8 @@ data InfoTable = InfoTable
     _infoInductives :: HashMap InductiveRef InductiveInfo,
     _infoFunctions :: HashMap FunctionRef FunctionInfo,
     _infoFunctionClauses :: HashMap S.Symbol (FunctionClause 'Scoped),
-    _infoNames :: [S.Name]
+    _infoNames :: [S.Name],
+    _infoCompilationRules :: HashMap S.Symbol CompileInfo
   }
   deriving stock (Eq, Show)
 
@@ -43,7 +48,8 @@ emptyInfoTable =
       _infoInductives = mempty,
       _infoFunctions = mempty,
       _infoFunctionClauses = mempty,
-      _infoNames = mempty
+      _infoNames = mempty,
+      _infoCompilationRules = mempty
     }
 
 makeLenses ''InfoTable
@@ -51,3 +57,4 @@ makeLenses ''InductiveInfo
 makeLenses ''ConstructorInfo
 makeLenses ''AxiomInfo
 makeLenses ''FunctionInfo
+makeLenses ''CompileInfo

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Name/NameKind.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Name/NameKind.hs
@@ -14,9 +14,9 @@ data NameKind
     KNameLocal
   | -- | An axiom.
     KNameAxiom
-  | -- | An local module name.
+  | -- | A local module name.
     KNameLocalModule
-  | -- | An top module name.
+  | -- | A top module name.
     KNameTopModule
   deriving stock (Show, Eq)
 
@@ -26,21 +26,32 @@ class HasNameKind a where
 instance HasNameKind NameKind where
   getNameKind = id
 
+isLocallyBounded :: HasNameKind a => a -> Bool
+isLocallyBounded k = case getNameKind k of
+  KNameLocal -> True
+  _ -> False
+
 isExprKind :: HasNameKind a => a -> Bool
 isExprKind k = case getNameKind k of
-  KNameConstructor -> True
-  KNameInductive -> True
-  KNameFunction -> True
-  KNameLocal -> True
-  KNameAxiom -> True
   KNameLocalModule -> False
   KNameTopModule -> False
+  _ -> True
 
 isModuleKind :: HasNameKind a => a -> Bool
 isModuleKind k = case getNameKind k of
   KNameLocalModule -> True
   KNameTopModule -> True
   _ -> False
+
+canBeCompiled :: HasNameKind a => a -> Bool
+canBeCompiled k = case getNameKind k of
+  KNameConstructor -> True
+  KNameInductive -> True
+  KNameFunction -> True
+  KNameAxiom -> True
+  KNameLocal -> False
+  KNameLocalModule -> False
+  KNameTopModule -> False
 
 canHaveFixity :: HasNameKind a => a -> Bool
 canHaveFixity k = case getNameKind k of

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Scope.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Scope.hs
@@ -35,7 +35,8 @@ data Scope = Scope
     _scopeFixities :: HashMap Symbol OperatorSyntaxDef,
     _scopeSymbols :: HashMap Symbol SymbolInfo,
     _scopeTopModules :: HashMap TopModulePath (ModuleRef'' 'S.NotConcrete 'ModuleTop),
-    _scopeBindGroup :: HashMap Symbol LocalVariable
+    _scopeBindGroup :: HashMap Symbol LocalVariable,
+    _scopeCompilationRules :: HashMap Symbol CompileInfo
   }
   deriving stock (Show)
 
@@ -75,5 +76,6 @@ emptyScope absPath =
       _scopeFixities = mempty,
       _scopeSymbols = mempty,
       _scopeTopModules = mempty,
-      _scopeBindGroup = mempty
+      _scopeBindGroup = mempty,
+      _scopeCompilationRules = mempty
     }

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Scoper.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Scoper.hs
@@ -798,7 +798,6 @@ checkCompile c@Compile {..} = do
             )
       | otherwise -> do
           _ <- checkBackendItems sym _compileBackendItems mempty
-          -- Maybe we can warn that certain backends are not supported yet.
           registerName (S.unqualifiedSymbol scopedSym)
           modify
             ( over
@@ -817,8 +816,6 @@ checkBackendItems _ [] bset = return bset
 checkBackendItems sym (b : bs) bset =
   let cBackend = b ^. backendItemBackend
    in if
-          | not (isBackendSupported cBackend) ->
-              throw (ErrUnsupportedBackend (UnsupportedBackend cBackend sym))
           | HashSet.member cBackend bset ->
               throw
                 ( ErrMultipleCompileRuleSameBackend

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Scoper.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Scoper.hs
@@ -29,7 +29,10 @@ import MiniJuvix.Syntax.Concrete.Scoped.Scope
 import MiniJuvix.Syntax.Concrete.Scoped.Scoper.InfoTableBuilder
 import MiniJuvix.Syntax.Concrete.Scoped.Scoper.ScoperResult
 
-entryScoper :: Members '[Error ScopeError, Files, NameIdGen] r => ParserResult -> Sem r ScoperResult
+entryScoper ::
+  Members '[Error ScopeError, Files, NameIdGen] r =>
+  ParserResult ->
+  Sem r ScoperResult
 entryScoper pr = do
   let root = pr ^. Parser.resultEntry . entryRoot
       modules = pr ^. Parser.resultModules
@@ -591,8 +594,7 @@ checkClausesExist ss = whenJust msig (throw . ErrLacksFunctionClause . LacksFunc
     msig =
       listToMaybe
         [ ts | StatementTypeSignature ts <- ss, null
-                                                  [ c | StatementFunctionClause c <- ss, c ^. clauseOwnerFunction == ts ^. sigName
-                                                  ]
+                                                  [c | StatementFunctionClause c <- ss, c ^. clauseOwnerFunction == ts ^. sigName]
         ]
 
 checkOrphanFixities :: forall r. Members '[Error ScopeError, State Scope] r => Sem r ()
@@ -768,17 +770,95 @@ lookupLocalEntry sym = do
     SymbolInfo {..} <- ms
     HashMap.lookup path _symbolInfo
 
+localScope :: Sem (Reader LocalVars : r) a -> Sem r a
+localScope = runReader (LocalVars mempty)
+
 checkAxiomDef ::
   Members '[InfoTableBuilder, Error ScopeError, State Scope, State ScoperState, NameIdGen] r =>
   AxiomDef 'Parsed ->
   Sem r (AxiomDef 'Scoped)
 checkAxiomDef AxiomDef {..} = do
-  axiomType' <- localScope $ checkParseExpressionAtoms _axiomType
+  axiomType' <- localScope (checkParseExpressionAtoms _axiomType)
   axiomName' <- bindAxiomSymbol _axiomName
   registerAxiom' AxiomDef {_axiomName = axiomName', _axiomType = axiomType', ..}
 
-localScope :: Sem (Reader LocalVars : r) a -> Sem r a
-localScope = runReader (LocalVars mempty)
+checkCompile ::
+  Members '[InfoTableBuilder, Error ScopeError, State Scope, Reader LocalVars, State ScoperState] r =>
+  Compile 'Parsed ->
+  Sem r (Compile 'Scoped)
+checkCompile c@Compile {..} = do
+  scopedSym :: S.Symbol <- checkCompileName c
+  let sym :: Symbol = c ^. compileName
+  rules <- gets _scopeCompilationRules
+  if
+      | HashMap.member sym rules ->
+          throw
+            ( ErrMultipleCompileBlockSameName
+                (MultipleCompileBlockSameName sym)
+            )
+      | otherwise -> do
+          _ <- checkBackendItems sym _compileBackendItems mempty
+          -- Maybe we can warn that certain backends are not supported yet.
+          registerName (S.unqualifiedSymbol scopedSym)
+          modify
+            ( over
+                scopeCompilationRules
+                (HashMap.insert _compileName (CompileInfo _compileBackendItems))
+            )
+          registerCompile' $ Compile {_compileName = scopedSym, ..}
+
+checkBackendItems ::
+  Members '[Error ScopeError] r =>
+  Symbol ->
+  [BackendItem] ->
+  HashSet Backend ->
+  Sem r (HashSet Backend)
+checkBackendItems _ [] bset = return bset
+checkBackendItems sym (b : bs) bset =
+  let cBackend = b ^. backendItemBackend
+   in if
+          | not (isBackendSupported cBackend) ->
+              throw (ErrUnsupportedBackend (UnsupportedBackend cBackend sym))
+          | HashSet.member cBackend bset ->
+              throw
+                ( ErrMultipleCompileRuleSameBackend
+                    (MultipleCompileRuleSameBackend b sym)
+                )
+          | otherwise -> checkBackendItems sym bs (HashSet.insert cBackend bset)
+
+checkCompileName ::
+  Members '[Error ScopeError, State Scope, Reader LocalVars, State ScoperState, InfoTableBuilder] r =>
+  Compile 'Parsed ->
+  Sem r S.Symbol
+checkCompileName Compile {..} = do
+  let sym :: Symbol = _compileName
+  let name :: Name = NameUnqualified sym
+  scope <- get
+  locals <- ask
+  entries <- lookupQualifiedSymbol ([], sym)
+  case filter S.canBeCompiled entries of
+    [] -> case entries of
+      [] -> throw (ErrSymNotInScope (NotInScope sym locals scope))
+      (e : _) ->
+        throw
+          ( ErrWrongKindExpressionCompileBlock
+              (WrongKindExpressionCompileBlock e)
+          )
+    [x] -> do
+      actualPath <- gets _scopePath
+      let scoped = entryToSymbol x sym
+      let expectedPath = scoped ^. S.nameDefinedIn
+      if
+          | actualPath == expectedPath -> return scoped
+          | otherwise ->
+              throw
+                ( ErrWrongLocationCompileBlock
+                    (WrongLocationCompileBlock expectedPath name)
+                )
+    xs -> throw (ErrAmbiguousSym (AmbiguousSym name xs))
+
+entryToSymbol :: SymbolEntry -> Symbol -> S.Symbol
+entryToSymbol sentry csym = set S.nameConcrete csym (symbolEntryToSName sentry)
 
 checkEval ::
   Members '[Error ScopeError, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r =>
@@ -868,7 +948,11 @@ checkLambdaClause LambdaClause {..} = do
         lambdaBody = lambdaBody'
       }
 
-scopedVar :: Members '[InfoTableBuilder] r => LocalVariable -> Symbol -> Sem r S.Symbol
+scopedVar ::
+  Members '[InfoTableBuilder] r =>
+  LocalVariable ->
+  Symbol ->
+  Sem r S.Symbol
 scopedVar (LocalVariable s) n = do
   let scoped = set S.nameConcrete n s
   registerName (S.unqualifiedSymbol scoped)
@@ -1088,7 +1172,8 @@ checkStatement s = case s of
   StatementAxiom ax -> StatementAxiom <$> checkAxiomDef ax
   StatementEval e -> StatementEval <$> checkEval e
   StatementPrint e -> StatementPrint <$> checkPrint e
-  StatementForeign d -> return $ StatementForeign d
+  StatementForeign d -> return (StatementForeign d)
+  StatementCompile c -> StatementCompile <$> checkCompile c
 
 -------------------------------------------------------------------------------
 -- Infix Expression

--- a/src/MiniJuvix/Syntax/MicroJuvix/InfoTable.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/InfoTable.hs
@@ -15,20 +15,24 @@ newtype FunctionInfo = FunctionInfo
   { _functionInfoType :: Type
   }
 
-data AxiomInfo = AxiomInfo
-  { _axiomInfoType :: Type,
-    _axiomInfoBackends :: [BackendItem]
+newtype AxiomInfo = AxiomInfo
+  { _axiomInfoType :: Type
   }
 
 newtype InductiveInfo = InductiveInfo
   { _inductiveInfoDef :: InductiveDef
   }
 
+newtype CompileInfo = CompileInfo
+  { _compileBackendItems :: [BackendItem]
+  }
+
 data InfoTable = InfoTable
   { _infoConstructors :: HashMap Name ConstructorInfo,
     _infoAxioms :: HashMap Name AxiomInfo,
     _infoFunctions :: HashMap Name FunctionInfo,
-    _infoInductives :: HashMap Name InductiveInfo
+    _infoInductives :: HashMap Name InductiveInfo,
+    _infoCompilationRules :: HashMap Name CompileInfo
   }
 
 -- TODO temporary function.
@@ -60,8 +64,14 @@ buildTable m = InfoTable {..}
     _infoAxioms :: HashMap Name AxiomInfo
     _infoAxioms =
       HashMap.fromList
-        [ (d ^. axiomName, AxiomInfo (d ^. axiomType) (d ^. axiomBackendItems))
+        [ (d ^. axiomName, AxiomInfo (d ^. axiomType))
           | StatementAxiom d <- ss
+        ]
+    _infoCompilationRules :: HashMap Name CompileInfo
+    _infoCompilationRules =
+      HashMap.fromList
+        [ (d ^. compileName, CompileInfo (d ^. compileBackendItems))
+          | StatementCompile d <- ss
         ]
     ss = m ^. (moduleBody . moduleStatements)
 
@@ -70,3 +80,4 @@ makeLenses ''FunctionInfo
 makeLenses ''ConstructorInfo
 makeLenses ''AxiomInfo
 makeLenses ''InductiveInfo
+makeLenses ''CompileInfo

--- a/src/MiniJuvix/Syntax/MicroJuvix/Language.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Language.hs
@@ -70,12 +70,17 @@ data Statement
   = StatementInductive InductiveDef
   | StatementFunction FunctionDef
   | StatementForeign ForeignBlock
+  | StatementCompile Compile
   | StatementAxiom AxiomDef
+
+data Compile = Compile
+  { _compileName :: Name,
+    _compileBackendItems :: [BackendItem]
+  }
 
 data AxiomDef = AxiomDef
   { _axiomName :: AxiomName,
-    _axiomType :: Type,
-    _axiomBackendItems :: [BackendItem]
+    _axiomType :: Type
   }
 
 data FunctionDef = FunctionDef
@@ -190,6 +195,7 @@ makeLenses ''Function
 makeLenses ''FunctionDef
 makeLenses ''FunctionClause
 makeLenses ''InductiveDef
+makeLenses ''Compile
 makeLenses ''AxiomDef
 makeLenses ''ModuleBody
 makeLenses ''Application

--- a/src/MiniJuvix/Syntax/MicroJuvix/TypeChecker.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/TypeChecker.hs
@@ -64,6 +64,7 @@ checkStatement s = case s of
   StatementForeign {} -> return s
   StatementInductive {} -> return s
   StatementAxiom {} -> return s
+  StatementCompile {} -> return s
 
 checkFunctionDef ::
   Members '[Reader InfoTable, Error TypeCheckerError] r =>

--- a/src/MiniJuvix/Syntax/MonoJuvix/InfoTable.hs
+++ b/src/MiniJuvix/Syntax/MonoJuvix/InfoTable.hs
@@ -14,15 +14,19 @@ newtype FunctionInfo = FunctionInfo
   { _functionInfoType :: Type
   }
 
-data AxiomInfo = AxiomInfo
-  { _axiomInfoType :: Type,
-    _axiomInfoBackends :: [BackendItem]
+newtype AxiomInfo = AxiomInfo
+  { _axiomInfoType :: Type
+  }
+
+newtype CompileInfo = CompileInfo
+  { _compileInfoBackendItems :: [BackendItem]
   }
 
 data InfoTable = InfoTable
   { _infoConstructors :: HashMap Name ConstructorInfo,
     _infoAxioms :: HashMap Name AxiomInfo,
-    _infoFunctions :: HashMap Name FunctionInfo
+    _infoFunctions :: HashMap Name FunctionInfo,
+    _infoCompilationRules :: HashMap Name CompileInfo
   }
 
 -- TODO temporary function.
@@ -47,8 +51,14 @@ buildTable m = InfoTable {..}
     _infoAxioms :: HashMap Name AxiomInfo
     _infoAxioms =
       HashMap.fromList
-        [ (d ^. axiomName, AxiomInfo (d ^. axiomType) (d ^. axiomBackendItems))
+        [ (d ^. axiomName, AxiomInfo (d ^. axiomType))
           | StatementAxiom d <- ss
+        ]
+    _infoCompilationRules :: HashMap Name CompileInfo
+    _infoCompilationRules =
+      HashMap.fromList
+        [ (d ^. compileName, CompileInfo (d ^. compileBackendItems))
+          | StatementCompile d <- ss
         ]
     ss = m ^. (moduleBody . moduleStatements)
 
@@ -56,3 +66,4 @@ makeLenses ''InfoTable
 makeLenses ''FunctionInfo
 makeLenses ''ConstructorInfo
 makeLenses ''AxiomInfo
+makeLenses ''CompileInfo

--- a/src/MiniJuvix/Syntax/MonoJuvix/Language.hs
+++ b/src/MiniJuvix/Syntax/MonoJuvix/Language.hs
@@ -63,12 +63,17 @@ data Statement
   = StatementInductive InductiveDef
   | StatementFunction FunctionDef
   | StatementForeign ForeignBlock
+  | StatementCompile Compile
   | StatementAxiom AxiomDef
+
+data Compile = Compile
+  { _compileName :: Name,
+    _compileBackendItems :: [BackendItem]
+  }
 
 data AxiomDef = AxiomDef
   { _axiomName :: AxiomName,
-    _axiomType :: Type,
-    _axiomBackendItems :: [BackendItem]
+    _axiomType :: Type
   }
 
 data FunctionDef = FunctionDef
@@ -162,6 +167,7 @@ makeLenses ''Application
 makeLenses ''TypedExpression
 makeLenses ''InductiveConstructorDef
 makeLenses ''ConstructorApp
+makeLenses ''Compile
 
 instance HasAtomicity Application where
   atomicity = const (Aggregate appFixity)

--- a/src/MiniJuvix/Syntax/MonoJuvix/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/MonoJuvix/Pretty/Base.hs
@@ -69,6 +69,9 @@ kwMapsto = keyword Str.mapstoUnicode
 kwForeign :: Doc Ann
 kwForeign = keyword Str.foreign_
 
+kwCompile :: Doc Ann
+kwCompile = keyword Str.compile
+
 kwAgda :: Doc Ann
 kwAgda = keyword Str.agda
 
@@ -200,14 +203,17 @@ instance PrettyCode ForeignBlock where
         <> line
         <> rbrace
 
+instance PrettyCode Compile where
+  ppCode Compile {..} = do
+    compileName' <- ppCode _compileName
+    compileBackendItems' <- ppBlock _compileBackendItems
+    return $ kwCompile <+> compileName' <+> compileBackendItems'
+
 instance PrettyCode AxiomDef where
   ppCode AxiomDef {..} = do
     axiomName' <- ppCode _axiomName
     axiomType' <- ppCode _axiomType
-    axiomBackendItems' <- case _axiomBackendItems of
-      [] -> return Nothing
-      bs -> Just <$> ppBlock bs
-    return $ kwAxiom <+> axiomName' <+> kwColon <+> axiomType' <+?> axiomBackendItems'
+    return $ kwAxiom <+> axiomName' <+> kwColon <+> axiomType'
 
 instance PrettyCode Statement where
   ppCode = \case
@@ -215,6 +221,7 @@ instance PrettyCode Statement where
     StatementFunction f -> ppCode f
     StatementInductive f -> ppCode f
     StatementAxiom f -> ppCode f
+    StatementCompile f -> ppCode f
 
 instance PrettyCode ModuleBody where
   ppCode m = do

--- a/src/MiniJuvix/Translation/AbstractToMicroJuvix.hs
+++ b/src/MiniJuvix/Translation/AbstractToMicroJuvix.hs
@@ -67,6 +67,13 @@ goStatement = \case
   A.StatementImport {} -> unsupported "imports"
   A.StatementLocalModule {} -> unsupported "local modules"
   A.StatementInductive i -> StatementInductive <$> goInductiveDef i
+  A.StatementCompile c -> StatementCompile <$> goCompile c
+
+goCompile :: A.Compile -> Sem r Compile
+goCompile c = return (Compile nameSym backends)
+  where
+    nameSym = goSymbol (c ^. A.compileName)
+    backends = c ^. A.compileBackendItems
 
 goTypeIden :: A.Iden -> TypeIden
 goTypeIden i = case i of
@@ -82,8 +89,7 @@ goAxiomDef a = do
   return
     AxiomDef
       { _axiomName = goSymbol (a ^. A.axiomName),
-        _axiomType = _axiomType',
-        _axiomBackendItems = a ^. A.axiomBackendItems
+        _axiomType = _axiomType'
       }
 
 goFunctionParameter :: A.FunctionParameter -> Sem r (Either VarName Type)

--- a/src/MiniJuvix/Translation/MicroJuvixToMonoJuvix.hs
+++ b/src/MiniJuvix/Translation/MicroJuvixToMonoJuvix.hs
@@ -58,6 +58,11 @@ goStatement = \case
   Micro.StatementFunction d -> StatementFunction <$> goFunctionDef d
   Micro.StatementForeign d -> return (StatementForeign d)
   Micro.StatementAxiom a -> StatementAxiom <$> goAxiomDef a
+  Micro.StatementCompile a -> StatementCompile <$> goCompile a
+
+goCompile :: Micro.Compile -> Sem r Compile
+goCompile Micro.Compile {..} = do
+  return Compile {_compileName = goName _compileName, ..}
 
 goAxiomDef :: Members '[Error Err, Reader Micro.InfoTable] r => Micro.AxiomDef -> Sem r AxiomDef
 goAxiomDef Micro.AxiomDef {..} = do
@@ -65,15 +70,14 @@ goAxiomDef Micro.AxiomDef {..} = do
   return
     AxiomDef
       { _axiomName = goName _axiomName,
-        _axiomType = _axiomType',
-        _axiomBackendItems = _axiomBackendItems
+        _axiomType = _axiomType'
       }
 
 lookupAxiom :: Members '[Error Err, Reader Micro.InfoTable] r => Micro.Name -> Sem r Micro.AxiomInfo
 lookupAxiom n =
   fromMaybe impossible . (^. Micro.infoAxioms . at n) <$> ask
 
-goIden :: Members '[Error Err, Reader Micro.InfoTable] r => Micro.Iden -> Sem r Iden
+goIden :: Micro.Iden -> Sem r Iden
 goIden = \case
   Micro.IdenFunction fun -> return (IdenFunction (goName fun))
   Micro.IdenConstructor c -> return (IdenConstructor (goName c))

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -162,5 +162,40 @@ tests =
       "AmbiguousConstructor.mjuvix"
       $ \case
         ErrAmbiguousSym {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Wrong location of a compile block"
+      "CompileBlocks"
+      "WrongLocationCompileBlock.mjuvix"
+      $ \case
+        ErrWrongLocationCompileBlock {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Multiple compile blocks for the same name"
+      "CompileBlocks"
+      "MultipleCompileBlockSameName.mjuvix"
+      $ \case
+        ErrMultipleCompileBlockSameName {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Multiple rules for a backend inside a compile block"
+      "CompileBlocks"
+      "MultipleCompileRuleSameBackend.mjuvix"
+      $ \case
+        ErrMultipleCompileRuleSameBackend {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Compile block for a unsupported kind of expression"
+      "CompileBlocks"
+      "WrongKindExpressionCompileBlock.mjuvix"
+      $ \case
+        ErrWrongKindExpressionCompileBlock {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Unsupported backend used in a compile block"
+      "CompileBlocks"
+      "UnsupportedBackend.mjuvix"
+      $ \case
+        ErrUnsupportedBackend {} -> Nothing
         _ -> wrongError
   ]

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -190,12 +190,5 @@ tests =
       "WrongKindExpressionCompileBlock.mjuvix"
       $ \case
         ErrWrongKindExpressionCompileBlock {} -> Nothing
-        _ -> wrongError,
-    NegTest
-      "Unsupported backend used in a compile block"
-      "CompileBlocks"
-      "UnsupportedBackend.mjuvix"
-      $ \case
-        ErrUnsupportedBackend {} -> Nothing
         _ -> wrongError
   ]

--- a/tests/negative/CompileBlocks/MultipleCompileBlockSameName.mjuvix
+++ b/tests/negative/CompileBlocks/MultipleCompileBlockSameName.mjuvix
@@ -1,0 +1,13 @@
+module MultipleCompileBlockSameName;
+
+axiom A : Type;
+
+compile A {
+  ghc -> "Bool";
+};
+
+compile A {
+  ghc -> "Bool";
+};
+
+end;

--- a/tests/negative/CompileBlocks/MultipleCompileRuleSameBackend.mjuvix
+++ b/tests/negative/CompileBlocks/MultipleCompileRuleSameBackend.mjuvix
@@ -1,0 +1,11 @@
+module MultipleCompileRuleSameBackend;
+
+
+axiom A : Type;
+
+compile A {
+  ghc -> "Bool";
+  ghc -> "Integer";
+};
+
+end;

--- a/tests/negative/CompileBlocks/Sample/Definitions.mjuvix
+++ b/tests/negative/CompileBlocks/Sample/Definitions.mjuvix
@@ -1,0 +1,13 @@
+module Sample.Definitions;
+
+axiom A : Type;
+
+inductive Nat {
+zero : Nat;
+suc : Nat -> Nat;
+};
+
+f : A -> Nat;
+f a := zero;
+
+end;

--- a/tests/negative/CompileBlocks/UnsupportedBackend.mjuvix
+++ b/tests/negative/CompileBlocks/UnsupportedBackend.mjuvix
@@ -1,9 +1,0 @@
-module UnsupportedBackend;
-
-axiom A : Type;
-compile A {
-  ghc -> "Bool";
-  agda -> "Bool";
-};
-
-end;

--- a/tests/negative/CompileBlocks/UnsupportedBackend.mjuvix
+++ b/tests/negative/CompileBlocks/UnsupportedBackend.mjuvix
@@ -1,0 +1,9 @@
+module UnsupportedBackend;
+
+axiom A : Type;
+compile A {
+  ghc -> "Bool";
+  agda -> "Bool";
+};
+
+end;

--- a/tests/negative/CompileBlocks/WrongKindExpressionCompileBlock.mjuvix
+++ b/tests/negative/CompileBlocks/WrongKindExpressionCompileBlock.mjuvix
@@ -1,0 +1,10 @@
+module WrongKindExpressionCompileBlock;
+
+module A;
+end;
+
+compile A {
+ghc -> "X";
+};
+
+end;

--- a/tests/negative/CompileBlocks/WrongLocationCompileBlock.mjuvix
+++ b/tests/negative/CompileBlocks/WrongLocationCompileBlock.mjuvix
@@ -1,0 +1,9 @@
+module WrongLocationCompileBlock;
+import Sample.Definitions;
+open Sample.Definitions;
+
+compile A {
+ ghc -> "Bool";
+};
+
+end;

--- a/tests/positive/Axiom.mjuvix
+++ b/tests/positive/Axiom.mjuvix
@@ -1,8 +1,8 @@
 module Axiom;
 
-axiom Action : Type {
+axiom Action : Type;
+compile Action {
  ghc ↦ "IO ()";
- agda ↦ "IO Unit";
 };
 
 end;

--- a/tests/positive/HelloWorld.mjuvix
+++ b/tests/positive/HelloWorld.mjuvix
@@ -13,9 +13,9 @@ import Data.Text.IO
 
 };
 
-axiom Action : Type {
+axiom Action : Type;
+compile Action {
  ghc ↦ "IO ()";
- agda   ↦ "void";
 };
 
 axiom String : Type;

--- a/tests/positive/MiniHaskell/HelloWorld.mjuvix
+++ b/tests/positive/MiniHaskell/HelloWorld.mjuvix
@@ -21,18 +21,21 @@ infixl 7 *;
 * zero b ≔ zero;
 * (suc a) b ≔ b + (a * b);
 
-axiom Action : Type {
+axiom Action : Type;
+compile Action {
  ghc ↦ "IO ()";
 };
 
 infixl 1 >>;
-axiom >> : Action → Action → Action {
+axiom >> : Action → Action → Action;
+compile >> {
   ghc ↦ "(>>)";
 };
 
 axiom String : Type;
 
-axiom putStr : String → Action {
+axiom putStr : String → Action;
+compile putStr {
   ghc ↦ "putStrLn";
 };
 

--- a/tests/positive/VP/SimpleFungibleToken.mjuvix
+++ b/tests/positive/VP/SimpleFungibleToken.mjuvix
@@ -27,15 +27,18 @@ infixr 3 &&;
 -- Backend Booleans
 --------------------------------------------------------------------------------
 
-axiom BackendBool : Type {
+axiom BackendBool : Type;
+compile BackendBool {
   ghc ↦ "Bool";
 };
 
-axiom backend-true : BackendBool {
+axiom backend-true : BackendBool;
+compile backend-true {
   ghc ↦ "True";
 };
 
-axiom backend-false : BackendBool {
+axiom backend-false : BackendBool;
+compile backend-false {
   ghc ↦ "False";
 };
 
@@ -49,7 +52,8 @@ foreign ghc {
   bool False _ y = y
 };
 
-axiom bool : BackendBool → Bool → Bool → Bool {
+axiom bool : BackendBool → Bool → Bool → Bool;
+compile bool {
   ghc ↦ "bool";
 };
 
@@ -60,11 +64,13 @@ from-backend-bool bb ≔ bool bb true false;
 -- Integers
 --------------------------------------------------------------------------------
 
-axiom Int : Type {
+axiom Int : Type;
+compile Int {
   ghc ↦ "Int";
 };
 
-axiom lt : Int → Int → BackendBool {
+axiom lt : Int → Int → BackendBool;
+compile lt {
   ghc ↦ "(<)";
 };
 
@@ -72,7 +78,8 @@ infix 4 <;
 < : Int → Int → Bool;
 < i1 i2 ≔ from-backend-bool (lt i1 i2);
 
-axiom eqInt : Int → Int → BackendBool {
+axiom eqInt : Int → Int → BackendBool;
+compile eqInt {
   ghc ↦ "(==)";
 };
 
@@ -81,12 +88,14 @@ infix 4 ==Int;
 ==Int i1 i2 ≔ from-backend-bool (eqInt i1 i2);
 
 infixl 6 -;
-axiom - : Int -> Int -> Int {
+axiom - : Int -> Int -> Int;
+compile - {
   ghc ↦ "(-)";
 };
 
 infixl 6 +;
-axiom + : Int -> Int -> Int {
+axiom + : Int -> Int -> Int;
+compile + {
   ghc ↦ "(+)";
 };
 
@@ -94,11 +103,13 @@ axiom + : Int -> Int -> Int {
 -- Strings
 --------------------------------------------------------------------------------
 
-axiom String : Type {
+axiom String : Type;
+compile String {
   ghc ↦ "[Char]";
 };
 
-axiom eqString : String → String → BackendBool {
+axiom eqString : String → String → BackendBool;
+compile eqString {
   ghc ↦ "(==)";
 };
 
@@ -179,15 +190,18 @@ foldl f z (Cons h hs) ≔ foldl f (f z h) hs;
 -- Anoma
 --------------------------------------------------------------------------------
 
-axiom readPre : String → Int {
+axiom readPre : String → Int;
+compile readPre {
   ghc ↦ "readPre";
 };
 
-axiom readPost : String → Int {
+axiom readPost : String → Int;
+compile readPost {
   ghc ↦ "readPost";
 };
 
-axiom isBalanceKey : String → String → String {
+axiom isBalanceKey : String → String → String;
+compile isBalanceKey {
   ghc ↦ "isBalanceKey";
 };
 
@@ -240,20 +254,25 @@ vp token keys-changed verifiers ≔
 -- IO
 --------------------------------------------------------------------------------
 
-axiom Action : Type {
+axiom Action : Type;
+compile Action {
  ghc ↦ "IO ()";
 };
 
-axiom putStr : String → Action {
+axiom putStr : String → Action;
+compile putStr {
   ghc ↦ "putStr";
 };
 
-axiom putStrLn : String → Action {
+axiom putStrLn : String → Action;
+compile putStrLn {
   ghc ↦ "putStrLn";
 };
 
 infixl 1 >>;
-axiom >> : Action → Action → Action {
+axiom >> : Action → Action → Action ;
+
+compile >> {
   ghc ↦ "(>>)";
 };
 


### PR DESCRIPTION
This PR supports the new keyword `compile` until scope checking.

The compile keyword has two arguments:

- A name of an expression to be compiled.
- A set of compilation rules using the format (`backend` → `string`) where the string is the text we inline.

This is an example:

```haskell
$ cat tests/positive/HelloWorld
...
axiom Action : Type;
compile Action {
 ghc ↦ "IO ()";
};
...
```

The following MiniJuvix examples are NOT valid.

- One can not repeat backend inside a `compile` block.

```haskell
...
axiom Action : Type;
compile Action {
 ghc ↦ "IO ()";
 ghc ↦ "IO ()";  -- 
};
...
```

- Use of unsupported backends. The Agda backend is not ready yet.
 
```haskell
...
axiom Action : Type;
compile Action {
 ghc ↦ "IO ()";
 agda ↦ "IO ()";
};
...
```

- One name, one compile block, no more.

```haskell
...
axiom Action : Type;
compile Action {
 ghc ↦ "IO ()";
};
compile Action {
 ghc ↦ "IO ()";
};
...
```

- A compile block must be in the same module as their name definition. 

```haskell
$ cat A.mjuvix
...
axiom Action : Type;
...
```

```haskell
$ cat B.mjuvix
...
compile Action {
 ghc ↦ "IO ()";
};
...
```
