### PR TITLE
check if stderr supports ANSI and print accordingly

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -386,7 +386,7 @@ runCLI cli = do
       micro <- head . (^. MicroTyped.resultModules) <$> runIO (upToMicroJuvixTyped (getEntryPoint root opts))
       case MicroTyped.checkModule micro of
         Right _ -> putStrLn "Well done! It type checks"
-        Left err -> printErrorAnsi err >> exitFailure
+        Left err -> printErrorAnsiSafe err >> exitFailure
     MiniHaskell o -> do
       minihaskell <- head . (^. MiniHaskell.resultModules) <$> runIO (upToMiniHaskell (getEntryPoint root o))
       renderStdOutMini (MiniHaskell.ppOutDefault minihaskell)

--- a/package.yaml
+++ b/package.yaml
@@ -18,6 +18,7 @@ extra-source-files:
 
 dependencies:
 - aeson == 2.0.*
+- ansi-terminal == 0.11.*
 - base == 4.16.*
 - blaze-html == 0.9.*
 - blaze-markup == 0.8.*
@@ -97,7 +98,6 @@ executables:
     main: Main.hs
     source-dirs: app
     dependencies:
-    - ansi-terminal == 0.11.*
     - minijuvix
     - optparse-applicative == 0.17.*
     verbatim:

--- a/src/MiniJuvix/Pipeline.hs
+++ b/src/MiniJuvix/Pipeline.hs
@@ -47,7 +47,7 @@ runIO = runIOEither >=> mayThrow
   where
     mayThrow :: Either AJuvixError r -> IO r
     mayThrow = \case
-      Left err -> printErrorAnsi err >> exitFailure
+      Left err -> printErrorAnsiSafe err >> exitFailure
       Right r -> return r
 
 --------------------------------------------------------------------------------

--- a/src/MiniJuvix/Prelude/Error.hs
+++ b/src/MiniJuvix/Prelude/Error.hs
@@ -4,6 +4,7 @@ module MiniJuvix.Prelude.Error where
 
 import MiniJuvix.Prelude.Base
 import System.Console.ANSI qualified as Ansi
+
 -- import System.IO qualified as IO
 
 -- | Wrapper for any instance of JuvixError.
@@ -36,9 +37,10 @@ throwJuvixError = throw . toAJuvixError
 
 printErrorAnsiSafe :: JuvixError e => e -> IO ()
 printErrorAnsiSafe e =
-  ifM (Ansi.hSupportsANSI stderr)
-  (printErrorAnsi e)
-  (printErrorText e)
+  ifM
+    (Ansi.hSupportsANSI stderr)
+    (printErrorAnsi e)
+    (printErrorText e)
 
 runErrorIO ::
   (JuvixError a, Member (Embed IO) r) =>

--- a/src/MiniJuvix/Prelude/Error.hs
+++ b/src/MiniJuvix/Prelude/Error.hs
@@ -3,6 +3,8 @@
 module MiniJuvix.Prelude.Error where
 
 import MiniJuvix.Prelude.Base
+import System.Console.ANSI qualified as Ansi
+-- import System.IO qualified as IO
 
 -- | Wrapper for any instance of JuvixError.
 data AJuvixError = forall e. JuvixError e => AJuvixError e
@@ -32,13 +34,19 @@ fromAJuvixError (AJuvixError e) = cast e
 throwJuvixError :: (JuvixError err, Member (Error AJuvixError) r) => err -> Sem r a
 throwJuvixError = throw . toAJuvixError
 
+printErrorAnsiSafe :: JuvixError e => e -> IO ()
+printErrorAnsiSafe e =
+  ifM (Ansi.hSupportsANSI stderr)
+  (printErrorAnsi e)
+  (printErrorText e)
+
 runErrorIO ::
   (JuvixError a, Member (Embed IO) r) =>
   Sem (Error a ': r) b ->
   Sem r b
 runErrorIO =
   runError >=> \case
-    Left err -> embed (printErrorAnsi err >> exitFailure)
+    Left err -> embed (printErrorAnsiSafe err >> exitFailure)
     Right a -> return a
 
 instance JuvixError Text where

--- a/test/Base.hs
+++ b/test/Base.hs
@@ -10,18 +10,6 @@ import MiniJuvix.Prelude
 import Test.Tasty
 import Test.Tasty.HUnit
 
--- parseModuleIO :: FilePath -> IO (M.Module 'M.Parsed 'M.ModuleTop)
--- parseModuleIO = fromRightIO id . Parser.runModuleParserIO
-
--- parseTextModuleIO :: Text -> IO (M.Module 'M.Parsed 'M.ModuleTop)
--- parseTextModuleIO = fromRightIO id . return . Parser.runModuleParser "literal string"
-
--- scopeModuleIO :: M.Module 'M.Parsed 'M.ModuleTop -> IO (M.Module 'M.Scoped 'M.ModuleTop)
--- scopeModuleIO = fmap (head . Scoper._resultModules) . fromRightIO' printErrorAnsi . Scoper.scopeCheck1IO "."
-
--- translateModuleIO :: M.Module 'M.Scoped 'M.ModuleTop -> IO A.TopModule
--- translateModuleIO = fmap snd . fromRightIO id . return . A.translateModule
-
 data AssertionDescr
   = Single Assertion
   | Steps ((String -> IO ()) -> Assertion)


### PR DESCRIPTION
This pr solves #38 

All usages of `printErrorAnsi` have been replaced by `printErrorAnsiSafe`, that only outputs colors when `stderr` supports it.
```
printErrorAnsiSafe :: JuvixError e => e -> IO ()
printErrorAnsiSafe e =
  ifM (Ansi.hSupportsANSI stderr)
 (printErrorAnsi e)
  (printErrorText e)
```

output to `stdout` has Ansi formatting iff `stdout` supports it and the user has not given the `--no-colors` flag.
This part was implemented in #63