### PR TITLE
Remove StatementCompile in AST after scoping

### DIFF
--- a/src/MiniJuvix/Syntax/Abstract/InfoTableBuilder.hs
+++ b/src/MiniJuvix/Syntax/Abstract/InfoTableBuilder.hs
@@ -15,7 +15,6 @@ data InfoTableBuilder m a where
   RegisterConstructor :: InductiveInfo -> InductiveConstructorDef -> InfoTableBuilder m ()
   RegisterInductive :: InductiveDef -> InfoTableBuilder m InductiveInfo
   RegisterFunction :: FunctionDef -> InfoTableBuilder m ()
-  RegisterCompile :: Compile -> InfoTableBuilder m ()
 
 makeSem ''InfoTableBuilder
 
@@ -62,10 +61,6 @@ toState = reinterpret $ \case
             { ..
             }
      in modify (over infoFunctions (HashMap.insert ref info))
-  RegisterCompile c ->
-    let name = c ^. compileName
-        backends = c ^. compileBackendItems
-     in modify (over infoCompilationRules (HashMap.insert name backends))
 
 runInfoTableBuilder :: Sem (InfoTableBuilder ': r) a -> Sem r (InfoTable, a)
 runInfoTableBuilder = runState emptyInfoTable . toState

--- a/src/MiniJuvix/Syntax/Abstract/Language.hs
+++ b/src/MiniJuvix/Syntax/Abstract/Language.hs
@@ -52,7 +52,6 @@ data Statement
   | StatementForeign ForeignBlock
   | StatementLocalModule LocalModule
   | StatementAxiom AxiomDef
-  | StatementCompile Compile
   deriving stock (Eq, Show)
 
 data FunctionDef = FunctionDef
@@ -195,12 +194,6 @@ data AxiomDef = AxiomDef
   }
   deriving stock (Eq, Show)
 
-data Compile = Compile
-  { _compileName :: S.Symbol,
-    _compileBackendItems :: [BackendItem]
-  }
-  deriving stock (Eq, Show)
-
 makeLenses ''Module
 makeLenses ''FunctionParameter
 makeLenses ''Function
@@ -215,7 +208,6 @@ makeLenses ''ConstructorRef
 makeLenses ''InductiveRef
 makeLenses ''AxiomRef
 makeLenses ''AxiomDef
-makeLenses ''Compile
 
 idenName :: Iden -> Name
 idenName = \case

--- a/src/MiniJuvix/Syntax/MicroJuvix/InfoTable.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/InfoTable.hs
@@ -23,16 +23,11 @@ newtype InductiveInfo = InductiveInfo
   { _inductiveInfoDef :: InductiveDef
   }
 
-newtype CompileInfo = CompileInfo
-  { _compileBackendItems :: [BackendItem]
-  }
-
 data InfoTable = InfoTable
   { _infoConstructors :: HashMap Name ConstructorInfo,
     _infoAxioms :: HashMap Name AxiomInfo,
     _infoFunctions :: HashMap Name FunctionInfo,
-    _infoInductives :: HashMap Name InductiveInfo,
-    _infoCompilationRules :: HashMap Name CompileInfo
+    _infoInductives :: HashMap Name InductiveInfo
   }
 
 -- TODO temporary function.
@@ -67,12 +62,6 @@ buildTable m = InfoTable {..}
         [ (d ^. axiomName, AxiomInfo (d ^. axiomType))
           | StatementAxiom d <- ss
         ]
-    _infoCompilationRules :: HashMap Name CompileInfo
-    _infoCompilationRules =
-      HashMap.fromList
-        [ (d ^. compileName, CompileInfo (d ^. compileBackendItems))
-          | StatementCompile d <- ss
-        ]
     ss = m ^. (moduleBody . moduleStatements)
 
 makeLenses ''InfoTable
@@ -80,4 +69,3 @@ makeLenses ''FunctionInfo
 makeLenses ''ConstructorInfo
 makeLenses ''AxiomInfo
 makeLenses ''InductiveInfo
-makeLenses ''CompileInfo

--- a/src/MiniJuvix/Syntax/MicroJuvix/Language.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Language.hs
@@ -6,7 +6,6 @@ module MiniJuvix.Syntax.MicroJuvix.Language
 where
 
 import MiniJuvix.Prelude
-import MiniJuvix.Syntax.Backends
 import MiniJuvix.Syntax.Concrete.Language (HasLoc)
 import MiniJuvix.Syntax.Concrete.Language qualified as C
 import MiniJuvix.Syntax.Concrete.Scoped.Name (NameId (..))
@@ -70,13 +69,7 @@ data Statement
   = StatementInductive InductiveDef
   | StatementFunction FunctionDef
   | StatementForeign ForeignBlock
-  | StatementCompile Compile
   | StatementAxiom AxiomDef
-
-data Compile = Compile
-  { _compileName :: Name,
-    _compileBackendItems :: [BackendItem]
-  }
 
 data AxiomDef = AxiomDef
   { _axiomName :: AxiomName,
@@ -195,7 +188,6 @@ makeLenses ''Function
 makeLenses ''FunctionDef
 makeLenses ''FunctionClause
 makeLenses ''InductiveDef
-makeLenses ''Compile
 makeLenses ''AxiomDef
 makeLenses ''ModuleBody
 makeLenses ''Application

--- a/src/MiniJuvix/Syntax/MicroJuvix/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Pretty/Base.hs
@@ -247,12 +247,6 @@ instance PrettyCode ForeignBlock where
         <> line
         <> rbrace
 
-instance PrettyCode Compile where
-  ppCode Compile {..} = do
-    name <- ppCode _compileName
-    backends <- ppBlock _compileBackendItems
-    return $ kwCompile <+> name <+> backends
-
 instance PrettyCode AxiomDef where
   ppCode AxiomDef {..} = do
     axiomName' <- ppCode _axiomName
@@ -265,7 +259,6 @@ instance PrettyCode Statement where
     StatementFunction f -> ppCode f
     StatementInductive f -> ppCode f
     StatementAxiom f -> ppCode f
-    StatementCompile f -> ppCode f
 
 instance PrettyCode ModuleBody where
   ppCode m = do

--- a/src/MiniJuvix/Syntax/MicroJuvix/TypeChecker.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/TypeChecker.hs
@@ -64,7 +64,6 @@ checkStatement s = case s of
   StatementForeign {} -> return s
   StatementInductive {} -> return s
   StatementAxiom {} -> return s
-  StatementCompile {} -> return s
 
 checkFunctionDef ::
   Members '[Reader InfoTable, Error TypeCheckerError] r =>
@@ -100,7 +99,6 @@ checkExpression t e = do
         )
 
 matchTypes ::
-  Members '[Reader InfoTable, Reader LocalVars] r =>
   Type ->
   Type ->
   Sem r Bool

--- a/src/MiniJuvix/Translation/AbstractToMicroJuvix.hs
+++ b/src/MiniJuvix/Translation/AbstractToMicroJuvix.hs
@@ -67,13 +67,6 @@ goStatement = \case
   A.StatementImport {} -> unsupported "imports"
   A.StatementLocalModule {} -> unsupported "local modules"
   A.StatementInductive i -> StatementInductive <$> goInductiveDef i
-  A.StatementCompile c -> StatementCompile <$> goCompile c
-
-goCompile :: A.Compile -> Sem r Compile
-goCompile c = return (Compile nameSym backends)
-  where
-    nameSym = goSymbol (c ^. A.compileName)
-    backends = c ^. A.compileBackendItems
 
 goTypeIden :: A.Iden -> TypeIden
 goTypeIden i = case i of

--- a/src/MiniJuvix/Translation/MicroJuvixToMonoJuvix.hs
+++ b/src/MiniJuvix/Translation/MicroJuvixToMonoJuvix.hs
@@ -58,11 +58,6 @@ goStatement = \case
   Micro.StatementFunction d -> StatementFunction <$> goFunctionDef d
   Micro.StatementForeign d -> return (StatementForeign d)
   Micro.StatementAxiom a -> StatementAxiom <$> goAxiomDef a
-  Micro.StatementCompile a -> StatementCompile <$> goCompile a
-
-goCompile :: Micro.Compile -> Sem r Compile
-goCompile Micro.Compile {..} = do
-  return Compile {_compileName = goName _compileName, ..}
 
 goAxiomDef :: Members '[Error Err, Reader Micro.InfoTable] r => Micro.AxiomDef -> Sem r AxiomDef
 goAxiomDef Micro.AxiomDef {..} = do

--- a/src/MiniJuvix/Translation/MonoJuvixToMiniHaskell.hs
+++ b/src/MiniJuvix/Translation/MonoJuvixToMiniHaskell.hs
@@ -13,7 +13,6 @@ import MiniJuvix.Syntax.MiniHaskell.MiniHaskellResult
 import MiniJuvix.Syntax.MonoJuvix.InfoTable qualified as Mono
 import MiniJuvix.Syntax.MonoJuvix.Language qualified as Mono
 import MiniJuvix.Syntax.MonoJuvix.MonoJuvixResult qualified as Mono
-import MiniJuvix.Translation.MicroJuvixToMonoJuvix (goCompile)
 import Prettyprinter
 
 -- import Base (Members)
@@ -63,7 +62,6 @@ goStatement = \case
   Mono.StatementFunction d -> Just . StatementFunction <$> goFunctionDef d
   Mono.StatementForeign d -> return (goForeign d)
   Mono.StatementAxiom {} -> return Nothing
-  Mono.StatementCompile d -> return Nothing
 
 goForeign :: ForeignBlock -> Maybe Statement
 goForeign b = case b ^. foreignBackend of


### PR DESCRIPTION
The scoped -> abstract translation does not emit StatementCompile (see: https://github.com/heliaxdev/minijuvix/blob/7392e8cc20b27f4bb600c8afcdc471cc1066147e/src/MiniJuvix/Translation/ScopedToAbstract.hs#L100)  and so any code dealing with StatementCompile after scoping was no-op.

The body of the compile block should be obtained from the scoping InfoTable `_infoCompilationRules` field https://github.com/heliaxdev/minijuvix/blob/7392e8cc20b27f4bb600c8afcdc471cc1066147e/src/MiniJuvix/Syntax/Concrete/Scoped/InfoTable.hs#L39