### PR TITLE
Add terminating keyword

### DIFF
--- a/app/Main.hs
+++ b/app/Main.hs
@@ -387,24 +387,30 @@ runCLI cli = do
       minihaskell <- head . (^. MiniHaskell.resultModules) <$> runIO (upToMiniHaskell (getEntryPoint root o))
       renderStdOutMini (MiniHaskell.ppOutDefault minihaskell)
     Termination (Calls opts@CallsOptions {..}) -> do
-      a <- head . (^. Abstract.resultModules) <$> runIO (upToAbstract (getEntryPoint root opts))
-      let callMap0 = T.buildCallMap a
+      results <- runIO (upToAbstract (getEntryPoint root opts))
+      let topModule = head (results ^. Abstract.resultModules)
+          infotable = results ^. Abstract.resultTable
+          callMap0 = T.buildCallMap infotable topModule
           callMap = case _callsFunctionNameFilter of
             Nothing -> callMap0
             Just f -> T.filterCallMap f callMap0
           opts' = T.callsPrettyOptions opts
       renderStdOutAbs (Abstract.ppOut opts' callMap)
       putStrLn ""
-    Termination (CallGraph o@CallGraphOptions {..}) -> do
-      a <- head . (^. Abstract.resultModules) <$> runIO (upToAbstract (getEntryPoint root o))
-      let callMap = T.buildCallMap a
+    Termination (CallGraph opts@CallGraphOptions {..}) -> do
+      results <- runIO (upToAbstract (getEntryPoint root opts))
+      let topModule = head (results ^. Abstract.resultModules)
+          infotable = results ^. Abstract.resultTable
+          callMap = T.buildCallMap infotable topModule
           opts' =
             Abstract.defaultOptions
               { Abstract._optShowNameId = globalOptions ^. globalShowNameIds
               }
           completeGraph = T.completeCallGraph callMap
           filteredGraph = maybe completeGraph (`T.unsafeFilterGraph` completeGraph) _graphFunctionNameFilter
-          recBehav = map T.recursiveBehaviour (T.reflexiveEdges filteredGraph)
+          rEdges = T.reflexiveEdges filteredGraph
+
+          recBehav = map T.recursiveBehaviour rEdges
       renderStdOutAbs (Abstract.ppOut opts' filteredGraph)
       putStrLn ""
       forM_ recBehav $ \r -> do
@@ -412,7 +418,7 @@ runCLI cli = do
               Scoper.defaultOptions
                 { Scoper._optShowNameId = globalOptions ^. globalShowNameIds
                 }
-            n = toAnsiText' (Scoper.ppOut sopts (A._recBehaviourFunction r))
+            n = toAnsiText' (Scoper.ppOut sopts (A._recursiveBehaviourFun r))
         renderStdOutAbs (Abstract.ppOut opts' r)
         putStrLn ""
         case T.findOrder r of

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -2,8 +2,6 @@
 
 module Main (main) where
 
---------------------------------------------------------------------------------
-
 import Commands.Extra
 import Commands.MicroJuvix
 import Commands.MiniHaskell
@@ -35,8 +33,6 @@ import Options.Applicative.Help.Pretty
 import System.Console.ANSI qualified as Ansi
 import System.IO qualified as IO
 import Text.Show.Pretty hiding (Html)
-
---------------------------------------------------------------------------------
 
 data GlobalOptions = GlobalOptions
   { _globalNoColors :: Bool,
@@ -420,7 +416,7 @@ runCLI cli = do
         renderStdOutAbs (Abstract.ppOut opts' r)
         putStrLn ""
         case T.findOrder r of
-          Nothing -> putStrLn (n <> " Fails the termination checking")
+          Nothing -> putStrLn (n <> " Fails the termination checking") >> exitFailure
           Just (T.LexOrder k) -> putStrLn (n <> " Terminates with order " <> show (toList k))
         putStrLn ""
 

--- a/lab/Syntax/Core.hs
+++ b/lab/Syntax/Core.hs
@@ -4,9 +4,6 @@
 
 module MiniJuvix.Syntax.Core where
 
---------------------------------------------------------------------------------
-
--- import Algebra.Graph.Label (Semiring (..))
 import MiniJuvix.Prelude hiding (Local)
 import Numeric.Natural (Natural)
 

--- a/src/MiniJuvix/Internal/Strings.hs
+++ b/src/MiniJuvix/Internal/Strings.hs
@@ -77,6 +77,9 @@ any = "Any"
 type_ :: IsString s => s
 type_ = "Type"
 
+questionMark :: IsString s => s
+questionMark = "?"
+
 keyword :: IsString s => s
 keyword = "keyword"
 
@@ -157,3 +160,6 @@ agda = "agda"
 
 terminating :: IsString s => s
 terminating = "terminating"
+
+waveArrow :: IsString s => s
+waveArrow = "↝"

--- a/src/MiniJuvix/Internal/Strings.hs
+++ b/src/MiniJuvix/Internal/Strings.hs
@@ -154,3 +154,6 @@ ghc = "ghc"
 
 agda :: IsString s => s
 agda = "agda"
+
+terminating :: IsString s => s
+terminating = "terminating"

--- a/src/MiniJuvix/Prelude/Base.hs
+++ b/src/MiniJuvix/Prelude/Base.hs
@@ -61,8 +61,6 @@ module MiniJuvix.Prelude.Base
   )
 where
 
---------------------------------------------------------------------------------
-
 import Control.Applicative
 import Control.Monad.Extra
 import Control.Monad.Fix
@@ -83,7 +81,17 @@ import Data.Hashable
 import Data.Int
 import Data.List.Extra hiding (head, last)
 import Data.List.NonEmpty qualified as NonEmpty
-import Data.List.NonEmpty.Extra (NonEmpty (..), head, last, maximum1, maximumOn1, minimum1, minimumOn1, nonEmpty, some1)
+import Data.List.NonEmpty.Extra
+  ( NonEmpty (..),
+    head,
+    last,
+    maximum1,
+    maximumOn1,
+    minimum1,
+    minimumOn1,
+    nonEmpty,
+    some1,
+  )
 import Data.Maybe
 import Data.Monoid
 import Data.Ord
@@ -119,26 +127,23 @@ import Prettyprinter (Doc, (<+>))
 import System.Directory
 import System.Exit
 import System.FilePath
-import System.IO hiding (appendFile, getContents, getLine, hGetContents, hGetLine, hPutStr, hPutStrLn, interact, putStr, putStrLn, readFile, readFile', writeFile)
+import System.IO hiding
+  ( appendFile,
+    getContents,
+    getLine,
+    hGetContents,
+    hGetLine,
+    hPutStr,
+    hPutStrLn,
+    interact,
+    putStr,
+    putStrLn,
+    readFile,
+    readFile',
+    writeFile,
+  )
 import Text.Show (Show)
 import Text.Show qualified as Show
-
---------------------------------------------------------------------------------
--- Logical connectives
---------------------------------------------------------------------------------
-
-(∨) :: Bool -> Bool -> Bool
-(∨) = (||)
-
-infixr 2 ∨
-
-(∧) :: Bool -> Bool -> Bool
-(∧) = (&&)
-
-infixr 3 ∧
-
-(.||.) :: (a -> Bool) -> (a -> Bool) -> a -> Bool
-(f .||. g) x = f x || g x
 
 --------------------------------------------------------------------------------
 -- High-level syntax sugar.
@@ -211,8 +216,6 @@ impossible :: HasCallStack => a
 impossible = Err.error "impossible"
 
 --------------------------------------------------------------------------------
--- Errors
---------------------------------------------------------------------------------
 
 infixl 7 <+?>
 
@@ -224,6 +227,8 @@ infixl 7 <?>
 (<?>) :: Semigroup m => m -> Maybe m -> m
 (<?>) a = maybe a (a <>)
 
+--------------------------------------------------------------------------------
+
 data Indexed a = Indexed
   { _indexedIx :: Int,
     _indexedThing :: a
@@ -234,6 +239,8 @@ instance Functor Indexed where
   fmap f (Indexed i a) = Indexed i (f a)
 
 makeLenses ''Indexed
+
+--------------------------------------------------------------------------------
 
 minimumMaybe :: (Foldable t, Ord a) => t a -> Maybe a
 minimumMaybe l = if null l then Nothing else Just (minimum l)

--- a/src/MiniJuvix/Prelude/Pretty.hs
+++ b/src/MiniJuvix/Prelude/Pretty.hs
@@ -30,3 +30,6 @@ toAnsiText useColors
 
 prettyText :: Pretty a => a -> Text
 prettyText = Text.renderStrict . layoutPretty defaultLayoutOptions . pretty
+
+vsep2 :: [Doc ann] -> Doc ann
+vsep2 = concatWith (\a b -> a <> line <> line <> b)

--- a/src/MiniJuvix/Syntax/Abstract/InfoTable.hs
+++ b/src/MiniJuvix/Syntax/Abstract/InfoTable.hs
@@ -7,6 +7,7 @@ import MiniJuvix.Syntax.Concrete.Scoped.Name qualified as S
 newtype FunctionInfo = FunctionInfo
   { _functionInfoDef :: FunctionDef
   }
+  deriving stock (Show)
 
 data ConstructorInfo = ConstructorInfo
   { _constructorInfoInductive :: InductiveInfo,

--- a/src/MiniJuvix/Syntax/Abstract/Language.hs
+++ b/src/MiniJuvix/Syntax/Abstract/Language.hs
@@ -57,7 +57,8 @@ data Statement
 data FunctionDef = FunctionDef
   { _funDefName :: FunctionName,
     _funDefTypeSig :: Expression,
-    _funDefClauses :: NonEmpty FunctionClause
+    _funDefClauses :: NonEmpty FunctionClause,
+    _funDefTerminating :: Bool
   }
   deriving stock (Eq, Show)
 

--- a/src/MiniJuvix/Syntax/Abstract/Language/Extra.hs
+++ b/src/MiniJuvix/Syntax/Abstract/Language/Extra.hs
@@ -7,22 +7,22 @@ where
 import MiniJuvix.Prelude
 import MiniJuvix.Syntax.Abstract.Language
 
+patternVariables :: Pattern -> [VarName]
+patternVariables pat = case pat of
+  PatternVariable v -> [v]
+  PatternWildcard {} -> []
+  PatternEmpty {} -> []
+  PatternConstructorApp app -> appVariables app
+
+appVariables :: ConstructorApp -> [VarName]
+appVariables (ConstructorApp _ ps) = concatMap patternVariables ps
+
 smallerPatternVariables :: Pattern -> [VarName]
-smallerPatternVariables p = case p of
+smallerPatternVariables = \case
   PatternVariable {} -> []
   PatternWildcard {} -> []
   PatternEmpty {} -> []
   PatternConstructorApp app -> appVariables app
-  where
-    appVariables :: ConstructorApp -> [VarName]
-    appVariables (ConstructorApp _ ps) = concatMap patternVariables ps
-
-    patternVariables :: Pattern -> [VarName]
-    patternVariables pat = case pat of
-      PatternVariable v -> [v]
-      PatternWildcard {} -> []
-      PatternEmpty {} -> []
-      PatternConstructorApp app -> appVariables app
 
 viewApp :: Expression -> (Expression, [Expression])
 viewApp e = case e of

--- a/src/MiniJuvix/Syntax/Concrete/Language.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Language.hs
@@ -17,8 +17,6 @@ module MiniJuvix.Syntax.Concrete.Language
   )
 where
 
---------------------------------------------------------------------------------
-
 import Data.Kind qualified as GHC
 import MiniJuvix.Prelude hiding (show)
 import MiniJuvix.Syntax.Backends
@@ -176,7 +174,8 @@ instance HasLoc OperatorSyntaxDef where
 
 data TypeSignature (s :: Stage) = TypeSignature
   { _sigName :: FunctionName s,
-    _sigType :: ExpressionType s
+    _sigType :: ExpressionType s,
+    _sigTerminating :: Bool
   }
 
 deriving stock instance (Show (ExpressionType s), Show (SymbolType s)) => Show (TypeSignature s)

--- a/src/MiniJuvix/Syntax/Concrete/Lexer.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Lexer.hs
@@ -1,7 +1,5 @@
 module MiniJuvix.Syntax.Concrete.Lexer where
 
---------------------------------------------------------------------------------
-
 import Data.Text qualified as Text
 import GHC.Unicode
 import MiniJuvix.Internal.Strings qualified as Str
@@ -258,6 +256,9 @@ kwSemicolon = keyword Str.semicolon
 
 kwType :: Member InfoTableBuilder r => ParsecS r ()
 kwType = keyword Str.type_
+
+kwTerminating :: Member InfoTableBuilder r => ParsecS r ()
+kwTerminating = keyword Str.terminating
 
 kwUsing :: Member InfoTableBuilder r => ParsecS r ()
 kwUsing = keyword Str.using

--- a/src/MiniJuvix/Syntax/Concrete/Parser.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Parser.hs
@@ -270,8 +270,11 @@ universe = do
 -- Type signature declaration
 -------------------------------------------------------------------------------
 
-typeSignature :: Member InfoTableBuilder r =>
-  Bool -> Symbol -> ParsecS r (TypeSignature 'Parsed)
+typeSignature ::
+  Member InfoTableBuilder r =>
+  Bool ->
+  Symbol ->
+  ParsecS r (TypeSignature 'Parsed)
 typeSignature _sigTerminating _sigName = do
   kwColon
   _sigType <- expressionAtoms

--- a/src/MiniJuvix/Syntax/Concrete/Parser.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Parser.hs
@@ -247,8 +247,7 @@ match = do
 --------------------------------------------------------------------------------
 
 letClause :: Member InfoTableBuilder r => ParsecS r (LetClause 'Parsed)
-letClause = do
-  either LetTypeSig LetFunClause <$> auxTypeSigFunClause
+letClause = either LetTypeSig LetFunClause <$> auxTypeSigFunClause
 
 letBlock :: Member InfoTableBuilder r => ParsecS r (LetBlock 'Parsed)
 letBlock = do
@@ -271,8 +270,9 @@ universe = do
 -- Type signature declaration
 -------------------------------------------------------------------------------
 
-typeSignature :: Member InfoTableBuilder r => Symbol -> ParsecS r (TypeSignature 'Parsed)
-typeSignature _sigName = do
+typeSignature :: Member InfoTableBuilder r =>
+  Bool -> Symbol -> ParsecS r (TypeSignature 'Parsed)
+typeSignature _sigTerminating _sigName = do
   kwColon
   _sigType <- expressionAtoms
   return TypeSignature {..}
@@ -286,9 +286,10 @@ auxTypeSigFunClause ::
   Member InfoTableBuilder r =>
   ParsecS r (Either (TypeSignature 'Parsed) (FunctionClause 'Parsed))
 auxTypeSigFunClause = do
-  s <- symbol
-  (Left <$> typeSignature s)
-    <|> (Right <$> functionClause s)
+  terminating <- isJust <$> optional kwTerminating
+  sym <- symbol
+  (Left <$> typeSignature terminating sym)
+    <|> (Right <$> functionClause sym)
 
 -------------------------------------------------------------------------------
 -- Axioms

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Scoper.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Scoper.hs
@@ -404,7 +404,7 @@ checkTypeSignature ::
 checkTypeSignature TypeSignature {..} = do
   sigType' <- checkParseExpressionAtoms _sigType
   sigName' <- bindFunctionSymbol _sigName
-  registerFunction' TypeSignature {_sigName = sigName', _sigType = sigType'}
+  registerFunction' TypeSignature {_sigName = sigName', _sigType = sigType', ..}
 
 checkConstructorDef ::
   Members '[Error ScopeError, Reader LocalVars, State Scope, State ScoperState, InfoTableBuilder, NameIdGen] r =>

--- a/src/MiniJuvix/Termination/CallGraph.hs
+++ b/src/MiniJuvix/Termination/CallGraph.hs
@@ -7,13 +7,14 @@ where
 import Data.HashMap.Strict qualified as HashMap
 import Data.HashSet qualified as HashSet
 import MiniJuvix.Prelude
+import MiniJuvix.Prelude.Pretty
 import MiniJuvix.Syntax.Abstract.Language.Extra
 import MiniJuvix.Syntax.Abstract.Pretty.Base
 import MiniJuvix.Syntax.Concrete.Scoped.Name qualified as S
 import MiniJuvix.Termination.Types
 import Prettyprinter as PP
 
-type Edges = HashMap (FunctionName, FunctionName) Edge
+type Graph = HashMap (FunctionName, FunctionName) Edge
 
 data Edge = Edge
   { _edgeFrom :: FunctionName,
@@ -21,37 +22,28 @@ data Edge = Edge
     _edgeMatrices :: HashSet CallMatrix
   }
 
-newtype CompleteCallGraph = CompleteCallGraph Edges
+newtype CompleteCallGraph = CompleteCallGraph Graph
 
 data ReflexiveEdge = ReflexiveEdge
-  { _redgeFun :: FunctionName,
-    _redgeMatrices :: HashSet CallMatrix
+  { _reflexiveEdgeFun :: FunctionName,
+    _reflexiveEdgeMatrices :: HashSet CallMatrix
   }
 
 data RecursiveBehaviour = RecursiveBehaviour
-  { _recBehaviourFunction :: FunctionName,
-    _recBehaviourMatrix :: [[Rel]]
+  { _recursiveBehaviourFun :: FunctionName,
+    _recursiveBehaviourMatrix :: [[Rel]]
   }
 
-makeLenses ''RecursiveBehaviour
 makeLenses ''Edge
+makeLenses ''RecursiveBehaviour
 makeLenses ''ReflexiveEdge
 
-multiply :: CallMatrix -> CallMatrix -> CallMatrix
-multiply a b = map sumProdRow a
-  where
-    rowB :: Int -> CallRow
-    rowB i = CallRow $ case b !? i of
-      Just (CallRow (Just c)) -> Just c
-      _ -> Nothing
-    sumProdRow :: CallRow -> CallRow
-    sumProdRow (CallRow mr) = CallRow $ do
-      (ki, ra) <- mr
-      (j, rb) <- _callRow (rowB ki)
-      return (j, mul' ra rb)
+-------------------------------------------------------------------------------
+-- Misc
+-------------------------------------------------------------------------------
 
-multiplyMany :: HashSet CallMatrix -> HashSet CallMatrix -> HashSet CallMatrix
-multiplyMany r s = HashSet.fromList [multiply a b | a <- toList r, b <- toList s]
+fromEdgeList :: [Edge] -> Graph
+fromEdgeList l = HashMap.fromList [((e ^. edgeFrom, e ^. edgeTo), e) | e <- l]
 
 composeEdge :: Edge -> Edge -> Maybe Edge
 composeEdge a b = do
@@ -62,6 +54,44 @@ composeEdge a b = do
         _edgeTo = b ^. edgeTo,
         _edgeMatrices = multiplyMany (a ^. edgeMatrices) (b ^. edgeMatrices)
       }
+
+edgesCompose :: Graph -> Graph -> Graph
+edgesCompose g h =
+  fromEdgeList
+    (catMaybes [composeEdge u v | u <- toList g, v <- toList h])
+
+edgeUnion :: Edge -> Edge -> Edge
+edgeUnion a b
+  | a ^. edgeFrom == b ^. edgeFrom,
+    a ^. edgeTo == b ^. edgeTo =
+      Edge
+        (a ^. edgeFrom)
+        (a ^. edgeTo)
+        (HashSet.union (a ^. edgeMatrices) (b ^. edgeMatrices))
+  | otherwise = impossible
+
+edgesUnion :: Graph -> Graph -> Graph
+edgesUnion = HashMap.unionWith edgeUnion
+
+edgesCount :: Graph -> Int
+edgesCount es = sum [HashSet.size (e ^. edgeMatrices) | e <- toList es]
+
+multiply :: CallMatrix -> CallMatrix -> CallMatrix
+multiply a b = map sumProdRow a
+  where
+    rowB :: Int -> CallRow
+    rowB i = CallRow $ case b !? i of
+      Just (CallRow (Just c)) -> Just c
+      _ -> Nothing
+
+    sumProdRow :: CallRow -> CallRow
+    sumProdRow (CallRow mr) = CallRow $ do
+      (ki, ra) <- mr
+      (j, rb) <- _callRow (rowB ki)
+      return (j, mul' ra rb)
+
+multiplyMany :: HashSet CallMatrix -> HashSet CallMatrix -> HashSet CallMatrix
+multiplyMany r s = HashSet.fromList [multiply a b | a <- toList r, b <- toList s]
 
 fromFunCall :: FunctionRef -> FunCall -> Call
 fromFunCall caller fc =
@@ -78,60 +108,36 @@ unsafeFilterGraph funNames (CompleteCallGraph g) =
   CompleteCallGraph (HashMap.filterWithKey (\(f, _) _ -> S.symbolText f `elem` funNames) g)
 
 completeCallGraph :: CallMap -> CompleteCallGraph
-completeCallGraph cm = CompleteCallGraph (go startingEdges)
+completeCallGraph CallMap {..} = CompleteCallGraph (go startingEdges)
   where
-    startingEdges :: Edges
+    startingEdges :: Graph
     startingEdges = foldr insertCall mempty allCalls
       where
-        insertCall :: Call -> Edges -> Edges
+        insertCall :: Call -> Graph -> Graph
         insertCall Call {..} = HashMap.alter (Just . aux) (_callFrom, _callTo)
           where
             aux :: Maybe Edge -> Edge
             aux me = case me of
               Nothing -> Edge _callFrom _callTo (HashSet.singleton _callMatrix)
               Just e -> over edgeMatrices (HashSet.insert _callMatrix) e
+
     allCalls :: [Call]
     allCalls =
       [ fromFunCall caller funCall
-        | (caller, callerMap) <- HashMap.toList (cm ^. callMap),
+        | (caller, callerMap) <- HashMap.toList _callMap,
           (_, funCalls) <- HashMap.toList callerMap,
           funCall <- funCalls
       ]
 
-    go :: Edges -> Edges
-    go m
-      | edgesCount m == edgesCount m' = m
-      | otherwise = go m'
+    go :: Graph -> Graph
+    go g
+      | edgesCount g == edgesCount g' = g
+      | otherwise = go g'
       where
-        m' = step m
+        g' = step g
 
-    step :: Edges -> Edges
+    step :: Graph -> Graph
     step s = edgesUnion (edgesCompose s startingEdges) s
-
-    fromEdgeList :: [Edge] -> Edges
-    fromEdgeList l = HashMap.fromList [((e ^. edgeFrom, e ^. edgeTo), e) | e <- l]
-
-    edgesCompose :: Edges -> Edges -> Edges
-    edgesCompose a b =
-      fromEdgeList $
-        catMaybes
-          [composeEdge ea eb | ea <- toList a, eb <- toList b]
-
-    edgeUnion :: Edge -> Edge -> Edge
-    edgeUnion a b
-      | a ^. edgeFrom == b ^. edgeFrom,
-        a ^. edgeTo == b ^. edgeTo =
-          Edge
-            (a ^. edgeFrom)
-            (a ^. edgeTo)
-            (HashSet.union (a ^. edgeMatrices) (b ^. edgeMatrices))
-      | otherwise = impossible
-
-    edgesUnion :: Edges -> Edges -> Edges
-    edgesUnion = HashMap.unionWith edgeUnion
-
-    edgesCount :: Edges -> Int
-    edgesCount es = sum [HashSet.size (e ^. edgeMatrices) | e <- toList es]
 
 reflexiveEdges :: CompleteCallGraph -> [ReflexiveEdge]
 reflexiveEdges (CompleteCallGraph es) = mapMaybe reflexive (toList es)
@@ -155,14 +161,15 @@ callMatrixDiag m = [col i r | (i, r) <- zip [0 :: Int ..] m]
 recursiveBehaviour :: ReflexiveEdge -> RecursiveBehaviour
 recursiveBehaviour re =
   RecursiveBehaviour
-    (re ^. redgeFun)
-    (map callMatrixDiag (toList $ re ^. redgeMatrices))
+    (re ^. reflexiveEdgeFun)
+    (map callMatrixDiag (toList $ re ^. reflexiveEdgeMatrices))
 
 findOrder :: RecursiveBehaviour -> Maybe LexOrder
 findOrder rb = LexOrder <$> listToMaybe (mapMaybe (isLexOrder >=> nonEmpty) allPerms)
   where
     b0 :: [[Rel]]
-    b0 = rb ^. recBehaviourMatrix
+    b0 = rb ^. recursiveBehaviourMatrix
+
     indexed = map (zip [0 :: Int ..] . take minLength) b0
       where
         minLength = minimum (map length b0)
@@ -204,29 +211,32 @@ instance PrettyCode Edge where
   ppCode Edge {..} = do
     fromFun <- ppSCode _edgeFrom
     toFun <- ppSCode _edgeTo
-    matrices <- indent 2 . ppMatrices . zip [0 :: Int ..] <$> mapM ppCode (toList _edgeMatrices)
+    matrices <-
+      indent 2 . ppMatrices . zip [0 :: Int ..]
+        <$> mapM ppCode (toList _edgeMatrices)
     return $
-      pretty ("Edge" :: Text) <+> fromFun <+> waveFun <+> toFun <> line
+      pretty ("Edge" :: Text) <+> fromFun <+> kwWaveArrow <+> toFun <> line
         <> matrices
     where
       ppMatrices = vsep2 . map ppMatrix
       ppMatrix (i, t) =
-        pretty ("Matrix" :: Text) <+> pretty i <> colon <> line
-          <> t
+        pretty ("Matrix" :: Text) <+> pretty i <> colon <> line <> t
 
 instance PrettyCode CompleteCallGraph where
   ppCode :: forall r. Members '[Reader Options] r => CompleteCallGraph -> Sem r (Doc Ann)
-  ppCode (CompleteCallGraph edges) = do
-    es <- vsep2 <$> mapM ppCode (toList edges)
-    return $ pretty ("Complete Call Graph:" :: Text) <> line <> es
+  ppCode (CompleteCallGraph edges)
+    | null edges = return $ pretty ("Empty graph" :: Text)
+    | otherwise = do
+        es <- vsep2 <$> mapM ppCode (toList edges)
+        return $ pretty ("Complete call graph:" :: Text) <> line <> es <> pretty (length edges)
 
 instance PrettyCode RecursiveBehaviour where
-  ppCode :: forall r. Members '[Reader Options] r => RecursiveBehaviour -> Sem r (Doc Ann)
+  ppCode :: Members '[Reader Options] r => RecursiveBehaviour -> Sem r (Doc Ann)
   ppCode (RecursiveBehaviour f m0) = do
     f' <- ppSCode f
     let m' = vsep (map (PP.list . map pretty) m)
     return $
-      pretty ("Recursive behaviour of " :: Text) <> f' <> colon <> line
+      pretty ("Recursive behaviour of" :: Text) <+> f' <> colon <> line
         <> indent 2 (align m')
     where
       m = toList (HashSet.fromList m0)

--- a/src/MiniJuvix/Termination/Types.hs
+++ b/src/MiniJuvix/Termination/Types.hs
@@ -98,7 +98,7 @@ instance PrettyCode CallMap where
       ppEntry (fun, mcalls) = do
         fun' <- annotate AnnImportant <$> ppCode fun
         calls' <- vsep <$> mapM ppCode calls
-        return $ fun' <+> "↝" <+> align calls'
+        return $ fun' <+> kwWaveArrow <+> align calls'
         where
           calls = concat (HashMap.elems mcalls)
 

--- a/src/MiniJuvix/Termination/Types.hs
+++ b/src/MiniJuvix/Termination/Types.hs
@@ -44,8 +44,24 @@ newtype LexOrder = LexOrder (NonEmpty Int)
 makeLenses ''FunCall
 makeLenses ''CallMap
 
+filterCallMap :: Foldable f => f Text -> CallMap -> CallMap
+filterCallMap funNames =
+  over
+    callMap
+    ( HashMap.filterWithKey
+        ( \k _ ->
+            S.symbolText
+              (nameUnqualify (k ^. functionRefName))
+              `elem` funNames
+        )
+    )
+
 instance PrettyCode FunCall where
-  ppCode :: forall r. Members '[Reader Options] r => FunCall -> Sem r (Doc Ann)
+  ppCode ::
+    forall r.
+    Members '[Reader Options] r =>
+    FunCall ->
+    Sem r (Doc Ann)
   ppCode (FunCall f args) = do
     args' <- mapM ppArg args
     f' <- ppCode f
@@ -71,25 +87,20 @@ instance PrettyCode FunCall where
       dbrackets x = pretty '⟦' <> x <> pretty '⟧'
 
 instance PrettyCode CallMap where
-  ppCode :: forall r. Members '[Reader Options] r => CallMap -> Sem r (Doc Ann)
+  ppCode ::
+    forall r.
+    Members '[Reader Options] r =>
+    CallMap ->
+    Sem r (Doc Ann)
   ppCode (CallMap m) = vsep <$> mapM ppEntry (HashMap.toList m)
     where
       ppEntry :: (A.FunctionRef, HashMap A.FunctionRef [FunCall]) -> Sem r (Doc Ann)
       ppEntry (fun, mcalls) = do
         fun' <- annotate AnnImportant <$> ppCode fun
         calls' <- vsep <$> mapM ppCode calls
-        return $ fun' <+> waveFun <+> align calls'
+        return $ fun' <+> "↝" <+> align calls'
         where
           calls = concat (HashMap.elems mcalls)
-
-kwQuestion :: Doc Ann
-kwQuestion = annotate AnnKeyword "?"
-
-waveFun :: Doc ann
-waveFun = pretty ("↝" :: Text)
-
-vsep2 :: [Doc ann] -> Doc ann
-vsep2 = concatWith (\a b -> a <> line <> line <> b)
 
 instance PrettyCode CallRow where
   ppCode (CallRow r) = return $ case r of
@@ -99,6 +110,3 @@ instance PrettyCode CallRow where
 
 instance PrettyCode CallMatrix where
   ppCode l = vsep <$> mapM ppCode l
-
-filterCallMap :: Foldable f => f Text -> CallMap -> CallMap
-filterCallMap funNames = over callMap (HashMap.filterWithKey (\k _ -> S.symbolText (nameUnqualify (k ^. functionRefName)) `elem` funNames))

--- a/src/MiniJuvix/Termination/Types/SizeRelation.hs
+++ b/src/MiniJuvix/Termination/Types/SizeRelation.hs
@@ -1,12 +1,8 @@
 module MiniJuvix.Termination.Types.SizeRelation where
 
---------------------------------------------------------------------------------
-
 import Data.Semiring
 import MiniJuvix.Prelude
 import Prettyprinter
-
---------------------------------------------------------------------------------
 
 data Rel
   = RJust Rel'

--- a/src/MiniJuvix/Utils/Version.hs
+++ b/src/MiniJuvix/Utils/Version.hs
@@ -13,8 +13,6 @@ module MiniJuvix.Utils.Version
   )
 where
 
-------------------------------------------------------------------------------
-
 import Data.Version (showVersion)
 import Development.GitRev (gitBranch, gitCommitDate, gitHash)
 import MiniJuvix.Prelude hiding (Doc)
@@ -22,8 +20,6 @@ import Paths_minijuvix qualified
 import Prettyprinter as PP
 import Prettyprinter.Render.Text (renderIO)
 import System.Environment (getProgName)
-
-------------------------------------------------------------------------------
 
 versionDoc :: Doc Text
 versionDoc = PP.pretty (showVersion Paths_minijuvix.version)

--- a/tests/negative/Termination/Loop.mjuvix
+++ b/tests/negative/Termination/Loop.mjuvix
@@ -1,4 +1,4 @@
-module TerminatingKeyword;
+module NoLexOrde;
 
 axiom A : Type;
 

--- a/tests/negative/Termination/NoLexOrder.mjuxix
+++ b/tests/negative/Termination/NoLexOrder.mjuxix
@@ -1,0 +1,11 @@
+module TerminatingKeyword;
+
+axiom A : Type;
+
+f : A -> A -> A;
+g : A -> A -> A;
+
+g x y := f x x;
+f x y := g x (f x x);
+
+end;

--- a/tests/negative/Termination/ToEmpty.mjuvix
+++ b/tests/negative/Termination/ToEmpty.mjuvix
@@ -1,0 +1,6 @@
+module ToEmpty;
+  axiom A : Type;
+  inductive Empty {};
+  f : A -> Empty;
+  f x := f x;
+end;

--- a/tests/positive/Termination/TerminatingF.mjuvix
+++ b/tests/positive/Termination/TerminatingF.mjuvix
@@ -1,0 +1,13 @@
+module TerminatingF;
+
+axiom A : Type;
+
+terminating
+f : A -> A -> A;
+
+g : A -> A -> A;
+
+g x y := f x x;
+f x y := g x (f x x);
+
+end;

--- a/tests/positive/Termination/TerminatingG.mjuvix
+++ b/tests/positive/Termination/TerminatingG.mjuvix
@@ -1,0 +1,13 @@
+module TerminatingG;
+
+axiom A : Type;
+
+f : A -> A -> A;
+
+terminating
+g : A -> A -> A;
+
+g x y := f x x;
+f x y := g x (f x x);
+
+end;

--- a/tests/positive/Termination/ToEmpty.mjuvix
+++ b/tests/positive/Termination/ToEmpty.mjuvix
@@ -1,0 +1,7 @@
+module ToEmpty;
+  axiom A : Type;
+  inductive Empty {};
+  terminating
+  f : A -> Empty;
+  f x := f x;
+end;


### PR DESCRIPTION
This PR closes #11, waiting to be merged #70.

It's clear that the following MiniJuvix program doesn't pass the termination checker (because of the infinite recursion in
the declaration of `f`). 

```$ cat tests/negative/Termination/ToEmpty.mjuvix
module ToEmpty;
  axiom A : Type;
  inductive Empty {};
  f : A -> Empty;
  f x := f x;
end;
$ 
```

However, showing programs are terminating is tricky. So we want to have a way to bypass the termination checker. This is the initial purpose of the`terminating` keyword. The following is an example of using it that would make happy the termination checker.

```$ cat tests/positive/Termination/ToEmpty.mjuvix
module ToEmpty;
  axiom A : Type;
  inductive Empty {};

  terminating
  f : A -> Empty;
  f x := f x;
end;
```