### PR TITLE
Stricter stack builds and pedantic mode for CI 

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Build Haskell Project
         run: |
           cd main
-          make build
+          make ci-build
 
       - name: Download MiniJuvix-stdlib
         run: |
@@ -107,4 +107,4 @@ jobs:
         id: test
         run: |
           cd main
-          make test
+          make ci-test

--- a/Makefile
+++ b/Makefile
@@ -43,9 +43,12 @@ docs :
 build:
 	stack build --fast --jobs $(THREADS)
 
+.PHONY : ci-build
+ci-build:
+	stack build --fast --jobs $(THREADS) --pedantic
+
 build-watch:
 	stack build --fast --file-watch
-
 
 .PHONY : cabal
 cabal :
@@ -61,6 +64,10 @@ clean-full:
 .PHONY : test
 test:
 	stack test --fast --jobs $(THREADS)
+
+.PHONY : ci-test
+ci-test:
+	stack test --fast --jobs $(THREADS) --pedantic
 
 .PHONY : test-watch
 test-watch:

--- a/package.yaml
+++ b/package.yaml
@@ -58,15 +58,21 @@ dependencies:
 
 ghc-options:
 # Warnings
-- -Wall
-- -Wcompat
-- -Wderiving-defaults
-- -Widentities
-- -Wincomplete-patterns
-- -Wincomplete-record-updates
-- -Wincomplete-uni-patterns
-- -Wmissing-deriving-strategies
-- -Wredundant-constraints
+- -Weverything
+- -Wno-unused-packages
+- -Wno-missing-exported-signatures
+- -Wno-missing-import-lists
+- -Wno-missed-specialisations
+- -Wno-all-missed-specialisations
+- -Wno-unsafe
+- -Wno-safe
+- -Wno-missing-safe-haskell-mode
+- -Wno-missing-local-signatures
+- -Wno-monomorphism-restriction
+- -Wno-missing-kind-signatures
+- -Wno-missing-export-lists
+- -Wno-partial-fields
+
 # HIE Support
 - -fhide-source-paths
 - -fwrite-ide-info -hiedir=.hie

--- a/package.yaml
+++ b/package.yaml
@@ -17,7 +17,6 @@ extra-source-files:
 - CHANGELOG.org
 
 dependencies:
-- aeson == 2.0.*
 - ansi-terminal == 0.11.*
 - base == 4.16.*
 - blaze-html == 0.9.*


### PR DESCRIPTION
With this PR the CI will error on any GHC  warning listed in `ghc-options` from the file `package.yaml`.  Locally, one can check the same by running `make ci-build` or `make ci-test`. Basically, it just adds the option `pedantic` to `slack`.