### PR TITLE
Fix internal link in README

### DIFF
--- a/README.org
+++ b/README.org
@@ -80,7 +80,7 @@ precompiled archives from the [[https://github.com/WebAssembly/wasi-sdk/releases
   tar xf libclang_rt.builtins-wasm32-wasi-15.0.tar.gz
   #+end_src
 
-2. <<sysroot>>Extract the =wasi-sysroot-*.tar.gz= archive on your local system and set =WASI_SYSROOT_PATH= to its path.
+2. Extract the =wasi-sysroot-*.tar.gz= archive on your local system and set =WASI_SYSROOT_PATH= to its path.
 
   For example:
 
@@ -111,7 +111,7 @@ stack test --ta '-p "! /slow tests/"'
 In the following example a MiniJuvix file is compiled using the C backend. The
 result is compiled to WASM using [[https://llvm.org][Clang]] and then executed using [[https://wasmer.io][wasmer]].
 
-NB: Set the =WASI_SYSROOT_PATH= environment variable to the root of the WASI sysroot, see [[sysroot]].
+NB: Set the =WASI_SYSROOT_PATH= environment variable to the root of the WASI sysroot. See [[#Dependencies][Dependencies]] for instructions on how to install the sysroot.
 
 #+begin_src shell
 cd tests/positive/MiniC/HelloWorld


### PR DESCRIPTION
GitHub org renderer doesn't support internal links so we cannot use the `<<link>>` tags in the file. Instead we link using the HTML anchor in the rendered document.