### PR TITLE
Remove dev in the CI and other tweaks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ on:
   pull_request:
     branches:
       - main
-    types: 
+    types:
       - opened
       - reopened
       - synchronize
@@ -18,7 +18,7 @@ concurrency:
 jobs:
   not-a-draft:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.draft == true 
+    if: github.event.pull_request.draft == true
     steps:
       - name: Fails in order to indicate that pull request needs to be marked as
               ready to review.
@@ -58,6 +58,29 @@ jobs:
     - uses: actions/checkout@v2
     - uses: actions/setup-python@v2
     - uses: pre-commit/action@v2.0.3
+      with:
+        extra_args:
+          trailing-whitespace --all-files
+    - uses: pre-commit/action@v2.0.3
+      with:
+        extra_args:
+          end-of-file-fixer --all-files
+    - uses: pre-commit/action@v2.0.3
+      with:
+        extra_args:
+          check-yaml --all-files
+    - uses: pre-commit/action@v2.0.3
+      with:
+        extra_args:
+          check-added-large-files --all-files
+    - uses: pre-commit/action@v2.0.3
+      with:
+        extra_args:
+          check-case-conflict --all-files
+    - uses: pre-commit/action@v2.0.3
+      with:
+        extra_args:
+          mixed-line-ending --all-files
 
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,12 @@ on:
   pull_request:
     branches:
       - main
-    types: [opened, synchronize, reopened,review_requested, ready_for_review]
+    types: 
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+      - review_requested
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
@@ -18,6 +23,7 @@ jobs:
       name: Fails in order to indicate that pull request needs to be marked as
             ready to review.
       run: exit 1
+
   ormolu:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,13 @@ jobs:
         path: '["src/", "app/", "test/"]'
         fail-on: warning
 
+  pre-commit:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-python@v2
+    - uses: pre-commit/action@v2.0.3
+
   build:
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,9 +20,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.draft == true 
     steps:
-      name: Fails in order to indicate that pull request needs to be marked as
-            ready to review.
-      run: exit 1
+      - name: Fails in order to indicate that pull request needs to be marked as
+              ready to review.
+        run: exit 1
 
   ormolu:
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,23 @@
 name: MiniJuvix CI
 
 on:
-  push:
-    branches: [ main , dev ]
   pull_request:
     branches:
       - main
-      - dev
+    types: [opened, synchronize, reopened,review_requested, ready_for_review]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
-
+  not-a-draft:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == true 
+    steps:
+      name: Fails in order to indicate that pull request needs to be marked as
+            ready to review.
+      run: exit 1
   ormolu:
     runs-on: ubuntu-latest
     steps:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -15,7 +15,7 @@ repos:
     -   id: mixed-line-ending
 
 -   repo:  https://github.com/heliaxdev/minijuvix
-    rev: a54abcd6a50518476ee75b329e245c3341d02341
+    rev: f987ef1c13e75e6ed60e8e85c8afecb3f485e224
     hooks:
     -   id: ormolu
     -   id: hlint


### PR DESCRIPTION
Closes #89

- Removes dev from the CI
- Only PRs marked as opened/reopen/ready-for-review/review-request will trigger the CI. 
- No CI for PRs drafts.  You can test locally by running e.g. `make ci-test`.  
- Cancel any previous run triggered by the same PR/workflow reference.

- After merging this PR, I'll activate the branch policy that allows branch merging if the code has been tested with the latest commit in main. 