### PR TITLE
[app] Add compile command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,6 +66,7 @@ docs/*.html
 /src/MiniJuvix/Utils/OldParser.hs
 CHANGELOG.md
 UPDATES-FOR-CHANGELOG.org
+.minijuvix-build
 
 # C Code generation
 *.wasm

--- a/app/CLI.hs
+++ b/app/CLI.hs
@@ -39,6 +39,7 @@ cliMainFile = aux . (^. cliCommand)
       MiniHaskell s -> Just (s ^. miniHaskellInputFile)
       Highlight s -> Just (s ^. highlightInputFile)
       MiniC s -> Just (s ^. miniCInputFile)
+      Compile s -> Just (s ^. compileInputFile)
       MicroJuvix (TypeCheck s) -> Just (s ^. microJuvixTypeInputFile)
       MicroJuvix (Pretty s) -> Just (s ^. microJuvixPrettyInputFile)
       MonoJuvix s -> Just (s ^. monoJuvixInputFile)
@@ -58,6 +59,7 @@ makeAbsPaths = traverseOf cliCommand aux
       MiniHaskell s -> MiniHaskell <$> traverseOf miniHaskellInputFile makeAbsolute s
       Highlight s -> Highlight <$> traverseOf highlightInputFile makeAbsolute s
       MiniC s -> MiniC <$> traverseOf miniCInputFile makeAbsolute s
+      Compile s -> Compile <$> traverseOf compileInputFile makeAbsolute s
       MicroJuvix (TypeCheck s) -> MicroJuvix . TypeCheck <$> traverseOf microJuvixTypeInputFile makeAbsolute s
       MicroJuvix (Pretty s) -> MicroJuvix . Pretty <$> traverseOf microJuvixPrettyInputFile makeAbsolute s
       MonoJuvix s -> MonoJuvix <$> traverseOf monoJuvixInputFile makeAbsolute s

--- a/app/Command.hs
+++ b/app/Command.hs
@@ -11,9 +11,11 @@ module Command
     module Commands.Parse,
     module Commands.Scope,
     module Commands.Termination,
+    module Commands.Compile,
   )
 where
 
+import Commands.Compile
 import Commands.Extra
 import Commands.Html
 import Commands.MicroJuvix
@@ -35,6 +37,7 @@ data Command
   | Termination TerminationCommand
   | MiniHaskell MiniHaskellOptions
   | MiniC MiniCOptions
+  | Compile CompileOptions
   | MicroJuvix MicroJuvixCommand
   | MonoJuvix MonoJuvixOptions
   | DisplayVersion
@@ -85,6 +88,7 @@ parseCommand =
             commandMicroJuvix,
             commandMiniHaskell,
             commandMiniC,
+            commandCompile,
             commandHighlight
           ]
       )
@@ -124,6 +128,15 @@ parseCommand =
           info
             (MiniC <$> parseMiniC)
             (progDesc "Translate a MiniJuvix file to MiniC")
+
+    commandCompile :: Mod CommandFields Command
+    commandCompile = command "compile" minfo
+      where
+        minfo :: ParserInfo Command
+        minfo =
+          info
+            (Compile <$> parseCompile)
+            (progDesc "Compile a MiniJuvix file")
 
     commandHighlight :: Mod CommandFields Command
     commandHighlight = command "highlight" minfo

--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -24,7 +24,7 @@ data CompileOptions = CompileOptions
   { _compileInputFile :: FilePath,
     _compileTarget :: CompileTarget,
     _compileRuntime :: CompileRuntime,
-    _compileOutputFile :: FilePath
+    _compileOutputFile :: Maybe FilePath
   }
 
 makeLenses ''CompileOptions
@@ -41,6 +41,7 @@ parseCompile = do
           <> showDefaultWith targetShow
           <> help "select a target: wasm, c"
       )
+
   _compileRuntime <-
     option
       (eitherReader parseRuntime)
@@ -51,16 +52,18 @@ parseCompile = do
           <> showDefaultWith runtimeShow
           <> help "select a runtime: standalone, libc"
       )
+
   _compileOutputFile <-
-    option
-      str
-      ( long "output"
-          <> short 'o'
-          <> metavar "OUTPUT_FILE"
-          <> help "Path to output file"
-          <> action "file"
-          <> value "out"
-      )
+    optional $
+      option
+        str
+        ( long "output"
+            <> short 'o'
+            <> metavar "OUTPUT_FILE"
+            <> help "Path to output file"
+            <> action "file"
+        )
+
   _compileInputFile <- parserInputFile
 
   pure CompileOptions {..}
@@ -108,12 +111,15 @@ prepareRuntime projRoot o = do
   where
     standaloneRuntimeDir :: [(FilePath, BS.ByteString)]
     standaloneRuntimeDir = $(FE.makeRelativeToProject "minic-runtime/standalone" >>= FE.embedDir)
+
     libCRuntimeDir :: [(FilePath, BS.ByteString)]
     libCRuntimeDir = $(FE.makeRelativeToProject "minic-runtime/libc" >>= FE.embedDir)
+
     runtimeProjectDir :: [(FilePath, BS.ByteString)]
     runtimeProjectDir = case o ^. compileRuntime of
       RuntimeStandalone -> standaloneRuntimeDir
       RuntimeLibC -> libCRuntimeDir
+
     writeRuntime :: (FilePath, BS.ByteString) -> IO ()
     writeRuntime (filePath, contents) =
       BS.writeFile (projRoot </> minijuvixBuildDir </> takeFileName filePath) contents
@@ -127,6 +133,7 @@ clangCompile projRoot o = do
   where
     sysrootEnvVar :: IO (Either Text String)
     sysrootEnvVar = maybeToEither "Missing environment variable WASI_SYSROOT_PATH" <$> lookupEnv "WASI_SYSROOT_PATH"
+
     withSysrootPath :: String -> IO (Either Text ())
     withSysrootPath sysrootPath = runClang clangArgs
       where
@@ -134,8 +141,10 @@ clangCompile projRoot o = do
         clangArgs = case o ^. compileRuntime of
           RuntimeStandalone -> standaloneArgs sysrootPath outputFile inputFile
           RuntimeLibC -> libcArgs sysrootPath outputFile inputFile
+
         outputFile :: FilePath
-        outputFile = o ^. compileOutputFile
+        outputFile = fromMaybe (takeBaseName (o ^. compileInputFile) <> ".wasm") (o ^. compileOutputFile)
+
         inputFile :: FilePath
         inputFile = inputCFile projRoot o
 

--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -87,23 +87,23 @@ parseCompile = do
       RuntimeStandalone -> "standalone"
       RuntimeLibC -> "libc"
 
-inputCFile :: CompileOptions -> FilePath
-inputCFile o = minijuvixBuildDir </> outputMiniCFile
+inputCFile :: FilePath -> CompileOptions -> FilePath
+inputCFile projRoot o = projRoot </> minijuvixBuildDir </> outputMiniCFile
   where
     outputMiniCFile :: FilePath
     outputMiniCFile = takeBaseName (o ^. compileInputFile) <> ".c"
 
-runCompile :: CompileOptions -> Text -> IO (Either Text ())
-runCompile o minic = do
-  createDirectoryIfMissing True minijuvixBuildDir
-  TIO.writeFile (inputCFile o) minic
-  prepareRuntime o
+runCompile :: FilePath -> CompileOptions -> Text -> IO (Either Text ())
+runCompile projRoot o minic = do
+  createDirectoryIfMissing True (projRoot </> minijuvixBuildDir)
+  TIO.writeFile (inputCFile projRoot o) minic
+  prepareRuntime projRoot o
   case o ^. compileTarget of
-    TargetWasm -> clangCompile o
+    TargetWasm -> clangCompile projRoot o
     TargetC -> return (Right ())
 
-prepareRuntime :: CompileOptions -> IO ()
-prepareRuntime o = do
+prepareRuntime :: FilePath -> CompileOptions -> IO ()
+prepareRuntime projRoot o = do
   mapM_ writeRuntime runtimeProjectDir
   where
     standaloneRuntimeDir :: [(FilePath, BS.ByteString)]
@@ -116,10 +116,10 @@ prepareRuntime o = do
       RuntimeLibC -> libCRuntimeDir
     writeRuntime :: (FilePath, BS.ByteString) -> IO ()
     writeRuntime (filePath, contents) =
-      BS.writeFile (minijuvixBuildDir </> takeFileName filePath) contents
+      BS.writeFile (projRoot </> minijuvixBuildDir </> takeFileName filePath) contents
 
-clangCompile :: CompileOptions -> IO (Either Text ())
-clangCompile o = do
+clangCompile :: FilePath -> CompileOptions -> IO (Either Text ())
+clangCompile projRoot o = do
   v <- sysrootEnvVar
   case v of
     Left s -> return (Left s)
@@ -137,7 +137,7 @@ clangCompile o = do
         outputFile :: FilePath
         outputFile = o ^. compileOutputFile
         inputFile :: FilePath
-        inputFile = inputCFile o
+        inputFile = inputCFile projRoot o
 
 standaloneArgs :: FilePath -> FilePath -> FilePath -> [String]
 standaloneArgs sysrootPath wasmOutputFile inputFile =

--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -1,0 +1,178 @@
+{-# LANGUAGE ApplicativeDo #-}
+{-# LANGUAGE TemplateHaskell #-}
+
+module Commands.Compile where
+
+import Commands.Extra
+import Data.ByteString qualified as BS
+import Data.FileEmbed qualified as FE
+import Data.Text.IO qualified as TIO
+import MiniJuvix.Prelude hiding (Doc)
+import Options.Applicative
+import System.Environment
+import System.Process qualified as P
+
+minijuvixBuildDir :: FilePath
+minijuvixBuildDir = ".minijuvix-build"
+
+data CompileTarget = TargetC | TargetWasm
+  deriving stock (Show)
+
+data CompileRuntime = RuntimeStandalone | RuntimeLibC
+  deriving stock (Show)
+
+data CompileOptions = CompileOptions
+  { _compileInputFile :: FilePath,
+    _compileTarget :: CompileTarget,
+    _compileRuntime :: CompileRuntime,
+    _compileOutputFile :: FilePath
+  }
+
+makeLenses ''CompileOptions
+
+parseCompile :: Parser CompileOptions
+parseCompile = do
+  _compileTarget <-
+    option
+      (eitherReader parseTarget)
+      ( long "target"
+          <> short 't'
+          <> metavar "TARGET"
+          <> value TargetWasm
+          <> showDefaultWith targetShow
+          <> help "select a target: wasm, c"
+      )
+  _compileRuntime <-
+    option
+      (eitherReader parseRuntime)
+      ( long "runtime"
+          <> short 'r'
+          <> metavar "RUNTIME"
+          <> value RuntimeStandalone
+          <> showDefaultWith runtimeShow
+          <> help "select a runtime: standalone, libc"
+      )
+  _compileOutputFile <-
+    option
+      str
+      ( long "output"
+          <> short 'o'
+          <> metavar "OUTPUT_FILE"
+          <> help "Path to output file"
+          <> action "file"
+          <> value "out"
+      )
+  _compileInputFile <- parserInputFile
+
+  pure CompileOptions {..}
+  where
+    parseTarget :: String -> Either String CompileTarget
+    parseTarget = \case
+      "wasm" -> Right TargetWasm
+      "c" -> Right TargetC
+      s -> Left $ "unrecognised target: " <> s
+
+    targetShow :: CompileTarget -> String
+    targetShow = \case
+      TargetC -> "c"
+      TargetWasm -> "wasm"
+
+    parseRuntime :: String -> Either String CompileRuntime
+    parseRuntime = \case
+      "standalone" -> Right RuntimeStandalone
+      "libc" -> Right RuntimeLibC
+      s -> Left $ "unrecognised runtime: " <> s
+
+    runtimeShow :: CompileRuntime -> String
+    runtimeShow = \case
+      RuntimeStandalone -> "standalone"
+      RuntimeLibC -> "libc"
+
+inputCFile :: CompileOptions -> FilePath
+inputCFile o = minijuvixBuildDir </> outputMiniCFile
+  where
+    outputMiniCFile :: FilePath
+    outputMiniCFile = takeBaseName (o ^. compileInputFile) <> ".c"
+
+runCompile :: CompileOptions -> Text -> IO (Either Text ())
+runCompile o minic = do
+  createDirectoryIfMissing True minijuvixBuildDir
+  TIO.writeFile (inputCFile o) minic
+  prepareRuntime o
+  case o ^. compileTarget of
+    TargetWasm -> clangCompile o
+    TargetC -> return (Right ())
+
+prepareRuntime :: CompileOptions -> IO ()
+prepareRuntime o = do
+  mapM_ writeRuntime runtimeProjectDir
+  where
+    standaloneRuntimeDir :: [(FilePath, BS.ByteString)]
+    standaloneRuntimeDir = $(FE.makeRelativeToProject "minic-runtime/standalone" >>= FE.embedDir)
+    libCRuntimeDir :: [(FilePath, BS.ByteString)]
+    libCRuntimeDir = $(FE.makeRelativeToProject "minic-runtime/libc" >>= FE.embedDir)
+    runtimeProjectDir :: [(FilePath, BS.ByteString)]
+    runtimeProjectDir = case o ^. compileRuntime of
+      RuntimeStandalone -> standaloneRuntimeDir
+      RuntimeLibC -> libCRuntimeDir
+    writeRuntime :: (FilePath, BS.ByteString) -> IO ()
+    writeRuntime (filePath, contents) =
+      BS.writeFile (minijuvixBuildDir </> takeFileName filePath) contents
+
+clangCompile :: CompileOptions -> IO (Either Text ())
+clangCompile o = do
+  v <- sysrootEnvVar
+  case v of
+    Left s -> return (Left s)
+    Right sysrootPath -> withSysrootPath sysrootPath
+  where
+    sysrootEnvVar :: IO (Either Text String)
+    sysrootEnvVar = maybeToEither "Missing environment variable WASI_SYSROOT_PATH" <$> lookupEnv "WASI_SYSROOT_PATH"
+    withSysrootPath :: String -> IO (Either Text ())
+    withSysrootPath sysrootPath = runClang clangArgs
+      where
+        clangArgs :: [String]
+        clangArgs = case o ^. compileRuntime of
+          RuntimeStandalone -> standaloneArgs sysrootPath outputFile inputFile
+          RuntimeLibC -> libcArgs sysrootPath outputFile inputFile
+        outputFile :: FilePath
+        outputFile = o ^. compileOutputFile
+        inputFile :: FilePath
+        inputFile = inputCFile o
+
+standaloneArgs :: FilePath -> FilePath -> FilePath -> [String]
+standaloneArgs sysrootPath wasmOutputFile inputFile =
+  [ "-nodefaultlibs",
+    "-I",
+    minijuvixBuildDir,
+    "--target=wasm32-wasi",
+    "--sysroot",
+    sysrootPath,
+    "-o",
+    wasmOutputFile,
+    minijuvixBuildDir </> "walloc.c",
+    inputFile
+  ]
+
+libcArgs :: FilePath -> FilePath -> FilePath -> [String]
+libcArgs sysrootPath wasmOutputFile inputFile =
+  [ "-nodefaultlibs",
+    "-I",
+    minijuvixBuildDir,
+    "-lc",
+    "--target=wasm32-wasi",
+    "--sysroot",
+    sysrootPath,
+    "-o",
+    wasmOutputFile,
+    inputFile
+  ]
+
+runClang ::
+  [String] ->
+  IO (Either Text ())
+runClang args = do
+  (exitCode, _, err) <- P.readProcessWithExitCode "clang" args ""
+  case exitCode of
+    ExitSuccess -> return (Right ())
+    _ -> return (Left (pack err))

--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -1,5 +1,4 @@
 {-# LANGUAGE ApplicativeDo #-}
-{-# LANGUAGE TemplateHaskell #-}
 
 module Commands.Compile where
 

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -205,7 +205,7 @@ runCLI cli = do
       say miniC
     Compile o -> do
       miniC <- (^. MiniC.resultCCode) <$> runPipeline (upToMiniC (getEntryPoint root globalOptions o))
-      result <- embed (runCompile o miniC)
+      result <- embed (runCompile root o miniC)
       case result of
         Left err -> say ("Error: " <> err)
         _ -> return ()

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -113,6 +113,11 @@ instance HasEntryPoint MiniCOptions where
     where
       nT = opts ^. globalNoTermination
 
+instance HasEntryPoint CompileOptions where
+  getEntryPoint r opts = EntryPoint r nT . pure . (^. compileInputFile)
+    where
+      nT = opts ^. globalNoTermination
+
 instance HasEntryPoint CallsOptions where
   getEntryPoint r opts = EntryPoint r nT . pure . (^. callsInputFile)
     where
@@ -198,6 +203,12 @@ runCLI cli = do
     MiniC o -> do
       miniC <- (^. MiniC.resultCCode) <$> runPipeline (upToMiniC (getEntryPoint root globalOptions o))
       say miniC
+    Compile o -> do
+      miniC <- (^. MiniC.resultCCode) <$> runPipeline (upToMiniC (getEntryPoint root globalOptions o))
+      result <- embed (runCompile o miniC)
+      case result of
+        Left err -> say ("Error: " <> err)
+        _ -> return ()
     Termination (Calls opts@CallsOptions {..}) -> do
       results <- runPipeline (upToAbstract (getEntryPoint root globalOptions opts))
       let topModule = head (results ^. Abstract.resultModules)


### PR DESCRIPTION
The compile command drives the (external) clang compiler to build a WASM
binary from a minijuvix file.

```
Usage: minijuvix compile [-t|--target TARGET] [-r|--runtime RUNTIME]
                         [-o|--output OUTPUT_FILE] MINIJUVIX_FILE

  Compile a MiniJuvix file

Available options:
  -t,--target TARGET       select a target: wasm, c (default: wasm)
  -r,--runtime RUNTIME     select a runtime: standalone, libc
                           (default: standalone)
  -o,--output OUTPUT_FILE  Path to output file
  MINIJUVIX_FILE           Path to a .mjuvix file
  -h,--help                Show this help text
```

The intermediate C files are stored in .minijuvix-build directory
relative to the directory where the command is executed.

The user can specify which runtime (standalone and libc) to build
against.

The file-embed library is used to embed the runtime files into the
minijuvix binary.

NB: The `WASI_SYSROOT_PATH` environment variable (as described in the documentation) must still be set.

Examples:

```
cd tests/positive/MiniC/HelloWorld
minijuvix compile Input.mjuvix -o hello.wasm
wasmer hello.wasm
hello world!

ls .minijuvix/build
Input.c         minic-runtime.h walloc.c
```

```
cd tests/positive/MiniC/HelloWorld
minijuvix compile Input.mjuvix --runtime libc -o hello.wasm
wasmer hello.wasm

hello world!

ls .minijuvix-build
Input.c         minic-runtime.h
```