### PR TITLE
Add negative test for AppLeftImplicit

### DIFF
--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -24,7 +24,7 @@ testDescr NegTest {..} =
           _testRoot = tRoot,
           _testAssertion = Single $ do
             let entryPoint = defaultEntryPoint _file
-            res <- runIOEither (upToScoping entryPoint)
+            res <- runIOEither (upToAbstract entryPoint)
             case mapLeft fromMiniJuvixError res of
               Left (Just err) -> whenJust (_checkErr err) assertFailure
               Left Nothing -> assertFailure "The scope checker did not find an error."
@@ -174,6 +174,13 @@ tests =
       "WrongLocationCompileBlock.mjuvix"
       $ \case
         ErrWrongLocationCompileBlock {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Implicit argument on the left of an application"
+      "."
+      "AppLeftImplicit.mjuvix"
+      $ \case
+        ErrAppLeftImplicit {} -> Nothing
         _ -> wrongError,
     NegTest
       "Multiple compile blocks for the same name"

--- a/tests/negative/AppLeftImplicit.mjuvix
+++ b/tests/negative/AppLeftImplicit.mjuvix
@@ -1,0 +1,6 @@
+module AppLeftImplicit;
+
+ x : Type;
+ x ≔ {x};
+
+end;


### PR DESCRIPTION
The AppLeftImplicit implicit happens when we have an implicit argument by itself or on the left of an application. This error 
is catched during the translation to Abstract syntax. 
It is the only type of error that (currently) can happen during the translation.