### PR TITLE
Update README usage example to use the compile command

### DIFF
--- a/README.org
+++ b/README.org
@@ -64,11 +64,11 @@ NB: Set the =WASI_SYSROOT_PATH= environment variable to the root of the WASI sys
 
 #+begin_src shell
 cd tests/positive/MiniC/HelloWorld
-minijuvix minic Input.mjuvix | clang --target=wasm32-wasi -nodefaultlibs -lc --sysroot $WASI_SYSROOT_PATH -I../../../../minic-runtime/libc -x c - -o out.wasm && wasmer out.wasm
+minijuvix compile Input.mjuvix
+wasmer Input.wasm
 #+end_src
 
-#+RESULTS:
-: hello world!
+You should see the output: =hello world!=
 
 ** Other Documentation
 


### PR DESCRIPTION
Use the [compile](https://github.com/heliaxdev/minijuvix/issues/128) subcommand instead of invoking clang directly in the README usage example.