### PR TITLE
Fix: identifiers with a keyword prefix cannot be parsed

### DIFF
--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -157,7 +157,7 @@ tests =
       "Parsing"
       "."
       "Parsing.mjuvix",
-     PosTest
+    PosTest
       "open overrides open public"
       "."
       "ShadowPublicOpen.mjuvix"

--- a/test/Scope/Positive.hs
+++ b/test/Scope/Positive.hs
@@ -154,6 +154,10 @@ tests =
       "QualifiedConstructor"
       "M.mjuvix",
     PosTest
+      "Parsing"
+      "."
+      "Parsing.mjuvix",
+     PosTest
       "open overrides open public"
       "."
       "ShadowPublicOpen.mjuvix"

--- a/tests/positive/Parsing.mjuvix
+++ b/tests/positive/Parsing.mjuvix
@@ -1,0 +1,8 @@
+module Parsing;
+
+ let' : Type;
+ let' ≔ Type;
+
+ TypeMine : Type;
+ TypeMine := Type;
+end;


### PR DESCRIPTION
The only change required is that keywords must _not_ be followed by a character that's a valid character for an identifier.

Identifiers such as `printInt`, `let'`, `inn` are now accepted. 