### PR TITLE
Remove TypeAny and adapt typechecking for literals

### DIFF
--- a/src/MiniJuvix/Internal/Strings.hs
+++ b/src/MiniJuvix/Internal/Strings.hs
@@ -80,9 +80,6 @@ error = "error"
 string :: IsString s => s
 string = "string"
 
-any :: IsString s => s
-any = "Any"
-
 type_ :: IsString s => s
 type_ = "Type"
 

--- a/src/MiniJuvix/Syntax/MicroJuvix/Language.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Language.hs
@@ -203,7 +203,6 @@ data Type
   | TypeAbs TypeAbstraction
   | TypeHole Hole
   | TypeUniverse
-  | TypeAny
   deriving stock (Eq, Generic)
 
 instance Hashable Type
@@ -262,7 +261,6 @@ instance HasAtomicity Type where
     TypeFunction f -> atomicity f
     TypeUniverse -> Atom
     TypeHole {} -> Atom
-    TypeAny -> Atom
     TypeAbs a -> atomicity a
     TypeApp a -> atomicity a
 

--- a/src/MiniJuvix/Syntax/MicroJuvix/Language/Extra.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Language/Extra.hs
@@ -92,7 +92,6 @@ mkConcreteType = fmap ConcreteType . go
         l' <- go l
         r' <- go r
         return (TypeApp (TypeApplication l' r' i))
-      TypeAny -> return TypeAny
       TypeUniverse -> return TypeUniverse
       TypeFunction (Function l r) -> do
         l' <- go l
@@ -120,7 +119,6 @@ findHoles = go
       TypeAbs a -> go (a ^. typeAbsBody)
       TypeHole h -> HashSet.singleton h
       TypeUniverse -> mempty
-      TypeAny -> mempty
 
 hasHoles :: Type -> Bool
 hasHoles = not . HashSet.null . findHoles
@@ -134,7 +132,6 @@ typeAsExpression = go
         TypeIden i -> ExpressionIden (goTypeIden i)
         TypeApp a -> ExpressionApplication (goApp a)
         TypeFunction f -> ExpressionFunction (goFunction f)
-        TypeAny -> error "TODO TypeAny"
         TypeAbs {} -> error "TODO TypeAbs"
         TypeHole h -> ExpressionHole h
         TypeUniverse -> error "TODO TypeUniverse"
@@ -197,7 +194,6 @@ fillHolesType m = go
       TypeAbs a -> TypeAbs (goAbs a)
       TypeFunction f -> TypeFunction (goFunction f)
       TypeUniverse -> TypeUniverse
-      TypeAny -> TypeAny
       TypeHole h -> goHole h
       where
         goApp :: TypeApplication -> TypeApplication
@@ -330,7 +326,6 @@ concreteTypeToExpr = go . (^. unconcreteType)
       TypeApp (TypeApplication l r i) -> ExpressionApplication (Application (go l) (go r) i)
       TypeFunction (Function l r) -> ExpressionFunction (FunctionExpression (go l) (go r))
       TypeUniverse {} -> impossible
-      TypeAny {} -> impossible
       TypeHole {} -> impossible
     goIden :: TypeIden -> Iden
     goIden = \case
@@ -372,7 +367,6 @@ substitution m = go
       TypeAbs a -> TypeAbs (goAbs a)
       TypeFunction f -> TypeFunction (goFunction f)
       TypeUniverse -> TypeUniverse
-      TypeAny -> TypeAny
       TypeHole h -> TypeHole h
 
     goApp :: TypeApplication -> TypeApplication

--- a/src/MiniJuvix/Syntax/MicroJuvix/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Pretty/Base.hs
@@ -136,9 +136,6 @@ kwWhere = keyword Str.where_
 kwModule :: Doc Ann
 kwModule = keyword Str.module_
 
-kwAny :: Doc Ann
-kwAny = keyword Str.any
-
 kwType :: Doc Ann
 kwType = keyword Str.type_
 
@@ -183,7 +180,6 @@ instance PrettyCode Type where
     TypeIden i -> ppCode i
     TypeFunction f -> ppCode f
     TypeUniverse -> return kwType
-    TypeAny -> return kwAny
     TypeApp a -> ppCode a
     TypeAbs a -> ppCode a
     TypeHole h -> ppCode h

--- a/src/MiniJuvix/Syntax/MicroJuvix/TypeChecker/Inference.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/TypeChecker/Inference.hs
@@ -61,7 +61,6 @@ closeState = \case
             return (TypeFunction (Function a' b'))
           TypeAbs (TypeAbstraction v i b) -> TypeAbs . TypeAbstraction v i <$> goType b
           TypeUniverse -> return TypeUniverse
-          TypeAny -> return TypeAny
           TypeHole h' ->
             let st = fromJust (m ^. at h')
              in goHole h' st
@@ -123,8 +122,6 @@ re = reinterpret $ \case
           (TypeAbs a, TypeAbs b) -> goAbs a b
           (TypeFunction a, TypeFunction b) -> goFunction a b
           (TypeUniverse, TypeUniverse) -> return True
-          (TypeAny, _) -> return True
-          (_, TypeAny) -> return True
           (TypeHole h, a) -> goHole h a
           (a, TypeHole h) -> goHole h a
           -- TODO is the final wildcard bad style?

--- a/src/MiniJuvix/Syntax/MonoJuvix/Language.hs
+++ b/src/MiniJuvix/Syntax/MonoJuvix/Language.hs
@@ -146,7 +146,6 @@ data Type
   = TypeIden TypeIden
   | TypeFunction Function
   | TypeUniverse
-  | TypeAny
   deriving stock (Show, Eq)
 
 makeLenses ''Module
@@ -177,7 +176,6 @@ instance HasAtomicity Type where
     TypeIden {} -> Atom
     TypeFunction f -> atomicity f
     TypeUniverse -> Atom
-    TypeAny -> Atom
 
 instance HasAtomicity ConstructorApp where
   atomicity (ConstructorApp _ args)

--- a/src/MiniJuvix/Syntax/MonoJuvix/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/MonoJuvix/Pretty/Base.hs
@@ -108,9 +108,6 @@ kwWhere = keyword Str.where_
 kwModule :: Doc Ann
 kwModule = keyword Str.module_
 
-kwAny :: Doc Ann
-kwAny = keyword Str.any
-
 kwType :: Doc Ann
 kwType = keyword Str.type_
 
@@ -139,7 +136,6 @@ instance PrettyCode Type where
     TypeIden i -> ppCode i
     TypeFunction f -> ppCode f
     TypeUniverse -> return kwType
-    TypeAny -> return kwAny
 
 instance PrettyCode InductiveConstructorDef where
   ppCode c = do

--- a/src/MiniJuvix/Translation/MicroJuvixToMonoJuvix/TypeCallsMapBuilder.hs
+++ b/src/MiniJuvix/Translation/MicroJuvixToMonoJuvix/TypeCallsMapBuilder.hs
@@ -96,7 +96,6 @@ goType :: Members '[State TypeCallsMap, Reader Caller] r => Type -> Sem r ()
 goType = \case
   TypeIden {} -> return ()
   TypeApp a -> goTypeApplication a
-  TypeAny -> return ()
   TypeHole {} -> impossible
   TypeUniverse -> return ()
   TypeFunction f -> goFunction f

--- a/src/MiniJuvix/Translation/MonoJuvixToMiniC.hs
+++ b/src/MiniJuvix/Translation/MonoJuvixToMiniC.hs
@@ -972,7 +972,6 @@ goType t = case t of
   Mono.TypeIden ti -> getMonoType ti
   Mono.TypeFunction {} -> declFunctionPtrType
   Mono.TypeUniverse {} -> unsupported "TypeUniverse"
-  Mono.TypeAny {} -> unsupported "TypeAny"
   where
     getMonoType :: Mono.TypeIden -> CDeclType
     getMonoType = \case

--- a/src/MiniJuvix/Translation/MonoJuvixToMiniHaskell.hs
+++ b/src/MiniJuvix/Translation/MonoJuvixToMiniHaskell.hs
@@ -232,4 +232,3 @@ goType = \case
   Mono.TypeIden t -> goTypeIden t
   Mono.TypeFunction f -> TypeFunction <$> goFunction f
   Mono.TypeUniverse -> error "MiniHaskell: universes in types not supported"
-  Mono.TypeAny -> impossible


### PR DESCRIPTION
All literals are assigned the type `{A : Type} -> A`.
During monomorphization, the the type argument is deleted. That is `0 {Nat}` is compiled to `0`.