### PR TITLE
Allow `open import` statements

### DIFF
--- a/src/MiniJuvix/Syntax/Concrete/Language.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Language.hs
@@ -471,6 +471,7 @@ newtype ExportInfo = ExportInfo
 
 data OpenModule (s :: Stage) = OpenModule
   { _openModuleName :: ModuleRefType s,
+    _openModuleImport :: Bool,
     _openParameters :: [ExpressionType s],
     _openUsingHiding :: Maybe UsingHiding,
     _openPublic :: PublicAnn

--- a/src/MiniJuvix/Syntax/Concrete/Parser.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Parser.hs
@@ -473,6 +473,7 @@ atomicExpression = do
 openModule :: forall r. Members '[Reader ParserParams, InfoTableBuilder] r => ParsecS r (OpenModule 'Parsed)
 openModule = do
   kwOpen
+  _openModuleImport <- isJust <$> optional kwImport
   _openModuleName <- name
   _openParameters <- many atomicExpression
   _openUsingHiding <- optional usingOrHiding

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Pretty/Base.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Pretty/Base.hs
@@ -483,7 +483,10 @@ instance SingI s => PrettyCode (OpenModule s) where
     openUsingHiding' <- mapM ppUsingHiding _openUsingHiding
     openParameters' <- ppOpenParams
     let openPublic' = ppPublic
-    return $ keyword "open" <+> openModuleName' <+?> openParameters' <+?> openUsingHiding' <+?> openPublic'
+        import_
+          | _openModuleImport = Just Str.import_
+          | otherwise = Nothing
+    return $ kwOpen <+?> import_ <+> openModuleName' <+?> openParameters' <+?> openUsingHiding' <+?> openPublic'
     where
       ppAtom' = case sing :: SStage s of
         SParsed -> ppCodeAtom

--- a/src/MiniJuvix/Translation/ScopedToAbstract.hs
+++ b/src/MiniJuvix/Translation/ScopedToAbstract.hs
@@ -91,7 +91,7 @@ goStatement (Indexed idx s) =
     StatementAxiom d -> Just . Abstract.StatementAxiom <$> goAxiom d
     StatementImport (Import t) -> Just . Abstract.StatementImport <$> goModule t
     StatementOperator {} -> return Nothing
-    StatementOpenModule {} -> return Nothing
+    StatementOpenModule o -> goOpenModule o
     StatementEval {} -> unsupported "eval statements"
     StatementPrint {} -> unsupported "print statements"
     StatementInductive i -> Just . Abstract.StatementInductive <$> goInductive i
@@ -100,6 +100,17 @@ goStatement (Indexed idx s) =
     StatementTypeSignature {} -> return Nothing
     StatementFunctionClause {} -> return Nothing
     StatementCompile {} -> return Nothing
+
+goOpenModule :: forall r.
+  Members '[InfoTableBuilder, Error ScoperError] r =>
+   OpenModule 'Scoped  -> Sem r (Maybe Abstract.Statement)
+goOpenModule o
+ | o ^. openModuleImport =
+   case o ^. openModuleName of
+     ModuleRef' (SModuleTop :&: m) -> Just . Abstract.StatementImport <$>
+       goModule (m ^. moduleRefModule)
+     _ -> impossible
+ | otherwise = return Nothing
 
 goFunctionDef ::
   forall r.

--- a/src/MiniJuvix/Translation/ScopedToAbstract.hs
+++ b/src/MiniJuvix/Translation/ScopedToAbstract.hs
@@ -101,16 +101,19 @@ goStatement (Indexed idx s) =
     StatementFunctionClause {} -> return Nothing
     StatementCompile {} -> return Nothing
 
-goOpenModule :: forall r.
+goOpenModule ::
+  forall r.
   Members '[InfoTableBuilder, Error ScoperError] r =>
-   OpenModule 'Scoped  -> Sem r (Maybe Abstract.Statement)
+  OpenModule 'Scoped ->
+  Sem r (Maybe Abstract.Statement)
 goOpenModule o
- | o ^. openModuleImport =
-   case o ^. openModuleName of
-     ModuleRef' (SModuleTop :&: m) -> Just . Abstract.StatementImport <$>
-       goModule (m ^. moduleRefModule)
-     _ -> impossible
- | otherwise = return Nothing
+  | o ^. openModuleImport =
+      case o ^. openModuleName of
+        ModuleRef' (SModuleTop :&: m) ->
+          Just . Abstract.StatementImport
+            <$> goModule (m ^. moduleRefModule)
+        _ -> impossible
+  | otherwise = return Nothing
 
 goFunctionDef ::
   forall r.

--- a/tests/positive/MiniC/MultiModules/Input.mjuvix
+++ b/tests/positive/MiniC/MultiModules/Input.mjuvix
@@ -1,20 +1,15 @@
 module Input;
 
-import String;
-open String;
+open import String;
 
-import Bool;
-open Bool;
+open import Bool;
 
-import Pair;
-open Pair;
+open import Pair;
 
-import IO;
-open IO;
+open import IO;
 
 -- Not needed but useful for testing
-import Prelude;
-open Prelude;
+open import Prelude;
 
 bool-to-str : Bool → String;
 bool-to-str true ≔ "True";

--- a/tests/positive/MiniC/MultiModules/Prelude.mjuvix
+++ b/tests/positive/MiniC/MultiModules/Prelude.mjuvix
@@ -1,15 +1,11 @@
 module Prelude;
 
-import String;
-open String public;
+open import String public;
 
-import Bool;
-open Bool public;
+open import Bool public;
 
-import Pair;
-open Pair public;
+open import Pair public;
 
-import IO;
-open IO public;
+open import IO public;
 
 end;


### PR DESCRIPTION
Instead of having 

```
import Prelude;
open Prelude;
```

Let's simplify it by the expression:

```
open import Prelude;
```

The `where` blocks won't support this feature for now.  