### PR TITLE
Embed HTML assets in the minijuvix binary

### DIFF
--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Pretty/Html.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Pretty/Html.hs
@@ -1,5 +1,6 @@
 module MiniJuvix.Syntax.Concrete.Scoped.Pretty.Html (genHtml, Theme (..)) where
 
+import Data.ByteString qualified as BS
 import Data.Text qualified as Text
 import Data.Text.IO qualified as Text
 import Data.Text.Lazy (toStrict)
@@ -36,21 +37,14 @@ genHtml opts recursive theme entry = do
     copyAssetFiles :: IO ()
     copyAssetFiles = do
       createDirectoryIfMissing True toAssetsDir
-      mapM_ cpFile assetFiles
+      mapM_ writeAsset assetFiles
       where
-        fromAssetsDir :: FilePath
-        fromAssetsDir = $(assetsDir)
+        assetFiles :: [(FilePath, BS.ByteString)]
+        assetFiles = $(assetsDir)
+        writeAsset :: (FilePath, BS.ByteString) -> IO ()
+        writeAsset (filePath, fileContents) =
+          BS.writeFile (toAssetsDir </> takeFileName filePath) fileContents
         toAssetsDir = htmlPath </> "assets"
-        cpFile (fromDir, name, toDir) = copyFile (fromDir </> name) (toDir </> name)
-        assetFiles :: [(FilePath, FilePath, FilePath)]
-        assetFiles =
-          [ (fromAssetsDir, name, toAssetsDir)
-            | name <-
-                [ "highlight.js",
-                  "source-ayu-light.css",
-                  "source-nord.css"
-                ]
-          ]
 
     outputModule :: Module 'Scoped 'ModuleTop -> IO ()
     outputModule m = do

--- a/src/MiniJuvix/Utils/Paths.hs
+++ b/src/MiniJuvix/Utils/Paths.hs
@@ -1,8 +1,8 @@
 module MiniJuvix.Utils.Paths where
 
-import Language.Haskell.TH.Syntax as TH
+import Data.FileEmbed qualified as FE
+import Language.Haskell.TH.Syntax
 import MiniJuvix.Prelude
-import TH.RelativePaths
 
 assetsDir :: Q Exp
-assetsDir = pathRelativeToCabalPackage "assets" >>= TH.lift
+assetsDir = FE.makeRelativeToProject "assets" >>= FE.embedDir


### PR DESCRIPTION
closes #174 

The `minijuvix html` command can now be used independently of the git project checkout.