### PR TITLE
Upgrade to ghc-9.2.3

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest , macOS-latest]
-        ghc: ["9.2.2"]
+        ghc: ["9.2.3"]
     steps:
       - uses: actions/cache@v3
         name: Cache Stack
@@ -156,7 +156,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest , macOS-latest]
-        ghc: ["9.2.2"]
+        ghc: ["9.2.3"]
     steps:
       - uses: actions/cache@v3
         id: cache-build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,7 +184,7 @@ jobs:
           version: "13.0"
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Remove Clang's GCC alias for stack GHC install
-        if: runner.os == "macOS"
+        if: runner.os == 'macOS'
         run : rm `which gcc`
       - name: Download and extract wasi-sysroot
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -170,6 +170,10 @@ jobs:
         uses: actions/checkout@v2
         with:
           path: main
+      - name: Setup Stack GHC
+        run : |
+          cd main
+          stack setup
       - name: Cache LLVM and Clang
         id: cache-llvm
         uses: actions/cache@v3
@@ -183,9 +187,6 @@ jobs:
         with:
           version: "13.0"
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
-      - name: Remove Clang's GCC alias for stack GHC install
-        if: runner.os == 'macOS'
-        run : rm `which gcc`
       - name: Download and extract wasi-sysroot
         run: |
           curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz -OL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,8 @@ jobs:
         with:
           version: "13.0"
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
+      - name: Remove Clang's GCC alias for stack GHC install
+        run : rm `which gcc`
       - name: Download and extract wasi-sysroot
         run: |
           curl https://github.com/WebAssembly/wasi-sdk/releases/download/wasi-sdk-15/wasi-sysroot-15.0.tar.gz -OL

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -184,6 +184,7 @@ jobs:
           version: "13.0"
           cached: ${{ steps.cache-llvm.outputs.cache-hit }}
       - name: Remove Clang's GCC alias for stack GHC install
+        if: runner.os == "macOS"
         run : rm `which gcc`
       - name: Download and extract wasi-sysroot
         run: |

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,3 +1,3 @@
 ghc-options:
   "$locals": -optP-Wno-nonportable-include-path
-resolver: nightly-2022-05-03
+resolver: nightly-2022-06-15


### PR DESCRIPTION
[GHC-9.2.3 release notes](https://downloads.haskell.org/ghc/9.2.3/docs/html/users_guide/9.2.3-notes.html)

Already available on stackage: https://www.stackage.org/nightly-2022-06-15
[Supported by hls as well](https://github.com/haskell/haskell-language-server/commit/e64b61e7fd90c5c72a7224762b4b0e28a4f1d89f).

