### PR TITLE
Fix: Add check for constructor return types 

### DIFF
--- a/src/MiniJuvix/Pipeline.hs
+++ b/src/MiniJuvix/Pipeline.hs
@@ -113,7 +113,7 @@ pipelineMicroJuvix ::
   Members '[Error MiniJuvixError] r =>
   Abstract.AbstractResult ->
   Sem r MicroJuvix.MicroJuvixResult
-pipelineMicroJuvix = mapError (MiniJuvixError @MicroJuvix.TerminationError) . MicroJuvix.entryMicroJuvix
+pipelineMicroJuvix = MicroJuvix.entryMicroJuvix
 
 pipelineMicroJuvixArity ::
   Members '[Error MiniJuvixError, NameIdGen] r =>

--- a/src/MiniJuvix/Syntax/MicroJuvix/Error.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Error.hs
@@ -13,6 +13,7 @@ import MiniJuvix.Syntax.MicroJuvix.Error.Types
 
 data TypeCheckerError
   = ErrWrongConstructorType WrongConstructorType
+  | ErrWrongReturnType WrongReturnType
   | ErrArity ArityCheckerError
   | ErrWrongType WrongType
   | ErrUnsolvedMeta UnsolvedMeta
@@ -22,6 +23,7 @@ instance ToGenericError TypeCheckerError where
   genericError :: TypeCheckerError -> GenericError
   genericError = \case
     ErrWrongConstructorType e -> genericError e
+    ErrWrongReturnType e -> genericError e
     ErrArity e -> genericError e
     ErrWrongType e -> genericError e
     ErrUnsolvedMeta e -> genericError e

--- a/src/MiniJuvix/Syntax/MicroJuvix/Error/Types.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Error/Types.hs
@@ -55,7 +55,7 @@ instance ToGenericError WrongReturnType where
       i = getLoc ctorName
       j = getLoc (typeAsExpression (e ^. wrongReturnTypeActual))
       msg =
-        "The constructor" <+> ppCode ctorName <+> "has wrong return type:"
+        "The constructor" <+> ppCode ctorName <+> "has the wrong return type:"
           <> line
           <> indent' (ppCode (e ^. wrongReturnTypeActual))
           <> line

--- a/src/MiniJuvix/Syntax/MicroJuvix/Error/Types.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Error/Types.hs
@@ -4,6 +4,7 @@ import MiniJuvix.Prelude
 import MiniJuvix.Prelude.Pretty
 import MiniJuvix.Syntax.MicroJuvix.Error.Pretty
 import MiniJuvix.Syntax.MicroJuvix.Language
+import MiniJuvix.Syntax.MicroJuvix.Language.Extra
 
 -- | the type of the constructor used in a pattern does
 -- not match the type of the inductive being matched
@@ -33,6 +34,34 @@ instance ToGenericError WrongConstructorType where
           <> "but is expected to have type:"
           <> line
           <> indent' (ppCode (e ^. wrongCtorTypeExpected))
+
+data WrongReturnType = WrongReturnType
+  { _wrongReturnTypeConstructorName :: Name,
+    _wrongReturnTypeExpected :: Type,
+    _wrongReturnTypeActual :: Type
+  }
+
+makeLenses ''WrongReturnType
+
+instance ToGenericError WrongReturnType where
+  genericError e =
+    GenericError
+      { _genericErrorLoc = j,
+        _genericErrorMessage = prettyError msg,
+        _genericErrorIntervals = [i, j]
+      }
+    where
+      ctorName = e ^. wrongReturnTypeConstructorName
+      i = getLoc ctorName
+      j = getLoc (typeAsExpression (e ^. wrongReturnTypeActual))
+      msg =
+        "The constructor" <+> ppCode ctorName <+> "has wrong return type:"
+          <> line
+          <> indent' (ppCode (e ^. wrongReturnTypeActual))
+          <> line
+          <> "but is expected to have type:"
+          <> line
+          <> indent' (ppCode (e ^. wrongReturnTypeExpected))
 
 newtype UnsolvedMeta = UnsolvedMeta
   { _unsolvedMeta :: Hole

--- a/src/MiniJuvix/Syntax/MicroJuvix/Language/Extra.hs
+++ b/src/MiniJuvix/Syntax/MicroJuvix/Language/Extra.hs
@@ -411,7 +411,7 @@ foldExplicitApplication :: Expression -> [Expression] -> Expression
 foldExplicitApplication f = foldApplication f . zip (repeat Explicit)
 
 foldApplication :: Expression -> [(IsImplicit, Expression)] -> Expression
-foldApplication f args = case args of
+foldApplication f = \case
   [] -> f
   ((i, a) : as) -> foldApplication (ExpressionApplication (Application f a i)) as
 
@@ -434,3 +434,14 @@ unfoldTypeApplication (TypeApplication l' r' _) = second (|: r') (unfoldType l')
     unfoldType t = case t of
       TypeApp (TypeApplication l r _) -> second (`snoc` r) (unfoldType l)
       _ -> (t, [])
+
+foldTypeApp :: Type -> [Type] -> Type
+foldTypeApp ty = \case
+  [] -> ty
+  (p : ps) -> foldTypeApp (TypeApp (TypeApplication ty p Explicit)) ps
+
+foldTypeAppName :: Name -> [Name] -> Type
+foldTypeAppName tyName indParams =
+  foldTypeApp
+    (TypeIden (TypeIdenInductive tyName))
+    (map (TypeIden . TypeIdenVariable) indParams)

--- a/test/TypeCheck/Negative.hs
+++ b/test/TypeCheck/Negative.hs
@@ -76,5 +76,19 @@ tests =
       "MultiWrongType.mjuvix"
       $ \case
         ErrWrongType {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Wrong return type name for a constructor of a simple data type"
+      "MicroJuvix"
+      "WrongReturnType.mjuvix"
+      $ \case
+        ErrWrongReturnType {} -> Nothing
+        _ -> wrongError,
+    NegTest
+      "Wrong return type for a constructor of a data type with parameters "
+      "MicroJuvix"
+      "WrongReturnTypeParameters.mjuvix"
+      $ \case
+        ErrWrongReturnType {} -> Nothing
         _ -> wrongError
   ]

--- a/tests/negative/MicroJuvix/FunctionApplied.mjuvix
+++ b/tests/negative/MicroJuvix/FunctionApplied.mjuvix
@@ -1,6 +1,6 @@
 module FunctionApplied;
   inductive T (A : Type) {
-    c : A → T;
+    c : A → T A;
   };
 
   f : {A : Type} → A → T A;

--- a/tests/negative/MicroJuvix/WrongReturnType.mjuvix
+++ b/tests/negative/MicroJuvix/WrongReturnType.mjuvix
@@ -1,0 +1,8 @@
+module WrongReturnType;
+
+axiom B : Type;
+inductive A {
+c : B;
+};
+
+end;

--- a/tests/negative/MicroJuvix/WrongReturnTypeParameters.mjuvix
+++ b/tests/negative/MicroJuvix/WrongReturnTypeParameters.mjuvix
@@ -1,0 +1,7 @@
+module WrongReturnTypeParameters;
+
+inductive A (B : Type) {
+c : A;
+}
+
+end;

--- a/tests/negative/MicroJuvix/WrongReturnTypeParameters.mjuvix
+++ b/tests/negative/MicroJuvix/WrongReturnTypeParameters.mjuvix
@@ -2,6 +2,6 @@ module WrongReturnTypeParameters;
 
 inductive A (B : Type) {
 c : A;
-}
+};
 
 end;

--- a/tests/positive/Polymorphism.mjuvix
+++ b/tests/positive/Polymorphism.mjuvix
@@ -11,8 +11,7 @@ inductive Nat {
 
 inductive List (A : Type) {
  nil : List A;
- -- TODO check that the return type is saturated with the proper variable
- cons : A → List A → Nat;
+ cons : A → List A → List A;
 };
 
 inductive Bool {

--- a/tests/positive/PolymorphismHoles.mjuvix
+++ b/tests/positive/PolymorphismHoles.mjuvix
@@ -11,8 +11,7 @@ inductive Nat {
 
 inductive List (A : Type) {
  nil : List A;
- -- TODO check that the return type is saturated with the proper variable
- cons : A → List A → Nat;
+ cons : A → List A → List A;
 };
 
 inductive Bool {


### PR DESCRIPTION
This PR implements a check for the return type of a constructor when
declaring an inductive data type. The following examples do not pass the check:

```
module WrongReturnType;

axiom B : Type;
inductive A {
c : B;
};

end;
```

```
module WrongReturnTypeParameters;

inductive A (B : Type) {
c : A;
};

end;
``` 

