### PR TITLE
README: Include `--recursive` in git clone command to fetch stdlib

### DIFF
--- a/README.org
+++ b/README.org
@@ -58,7 +58,7 @@ program can be downloaded and installed with the following commands. You
 will need to have [[https://haskellstack.org][Stack]] installed.
 
 #+begin_src shell
-git clone https://github.com/heliaxdev/minijuvix.git
+git clone --recursive https://github.com/heliaxdev/minijuvix.git
 cd minijuvix
 stack install
 #+end_src

--- a/docs/org/getting-started/quick-start.org
+++ b/docs/org/getting-started/quick-start.org
@@ -14,7 +14,7 @@ program can be downloaded and installed with the following commands. You
 will need to have [[https://haskellstack.org][Stack]] installed.
 
 #+begin_src shell
-git clone https://github.com/heliaxdev/minijuvix.git
+git clone --recursive https://github.com/heliaxdev/minijuvix.git
 cd minijuvix
 stack install
 #+end_src


### PR DESCRIPTION
`--recursive` is needed to fetch the minijuvix-stdlib submodule at clone time. Without this tests will fail and installation will not have an embedded stdlib.