### PR TITLE
Perform ScopedToAbstract exactly once for each module

### DIFF
--- a/test/TypeCheck/Positive.hs
+++ b/test/TypeCheck/Positive.hs
@@ -82,5 +82,9 @@ tests =
     PosTest
       "Implicit arguments"
       "MicroJuvix"
-      "Implicit.mjuvix"
+      "Implicit.mjuvix",
+    PosTest
+      "Import a builtin multiple times"
+      "BuiltinsMultiImport"
+      "Input.mjuvix"
   ]

--- a/tests/positive/BuiltinsMultiImport/A.mjuvix
+++ b/tests/positive/BuiltinsMultiImport/A.mjuvix
@@ -1,0 +1,5 @@
+module A;
+
+import Nat;
+
+end;

--- a/tests/positive/BuiltinsMultiImport/Input.mjuvix
+++ b/tests/positive/BuiltinsMultiImport/Input.mjuvix
@@ -1,0 +1,6 @@
+module Input;
+
+import A;
+import Nat;
+
+end;

--- a/tests/positive/BuiltinsMultiImport/Nat.mjuvix
+++ b/tests/positive/BuiltinsMultiImport/Nat.mjuvix
@@ -1,0 +1,9 @@
+module Nat;
+
+builtin natural
+inductive Nat {
+  zero : Nat;
+  suc : Nat → Nat;
+};
+
+end;


### PR DESCRIPTION
This commit introduces a cache of Abstract.TopModule that is queried for
each ImportStatement.

Before this change, `registerBuiltin` could be called multiple times for
a module, if it was imported multiple times.

Closes #220 