### PR TITLE
 Use the ModulesCache for `open` statements in ScopedToAbstract pass

### DIFF
--- a/src/MiniJuvix/Translation/ScopedToAbstract.hs
+++ b/src/MiniJuvix/Translation/ScopedToAbstract.hs
@@ -49,32 +49,28 @@ goModule ::
   (Members '[InfoTableBuilder, Error ScoperError, Builtins, NameIdGen, State ModulesCache] r, SingI t) =>
   Module 'Scoped t ->
   Sem r Abstract.Module
-goModule (Module n par b) = case par of
-  [] -> do
-    am <- Abstract.Module modName <$> goModuleBody b
-    updateCache am
-    return am
-  _ -> unsupported "Module parameters"
+goModule m = case sing :: SModuleIsTop t of
+  SModuleTop -> do
+    cache <- gets (^. cachedModules)
+    let moduleNameId :: S.NameId
+        moduleNameId = m ^. Concrete.modulePath . S.nameId
+    let processModule :: Sem r Abstract.Module
+        processModule = do
+          am <- goModule' m
+          modify (over cachedModules (HashMap.insert moduleNameId am))
+          return am
+    maybe processModule return (cache ^. at moduleNameId)
+  SModuleLocal -> goModule' m
   where
-    updateCache :: Abstract.Module -> Sem r ()
-    updateCache am = case sing :: SModuleIsTop t of
-      SModuleTop -> modify (over cachedModules (HashMap.insert (n ^. S.nameId) am))
-      SModuleLocal -> return ()
-    modName :: Abstract.Name
-    modName = case sing :: SModuleIsTop t of
-      SModuleTop -> goSymbol (S.topModulePathName n)
-      SModuleLocal -> goSymbol n
-
-goModuleOrCache ::
-  forall r.
-  Members '[InfoTableBuilder, Error ScoperError, Builtins, NameIdGen, State ModulesCache] r =>
-  Module 'Scoped 'ModuleTop ->
-  Sem r Abstract.Module
-goModuleOrCache m = do
-  cache <- gets (^. cachedModules)
-  let moduleNameId :: S.NameId
-      moduleNameId = m ^. Concrete.modulePath . S.nameId
-  maybe (goModule m) return (cache ^. at moduleNameId)
+    goModule' :: Module 'Scoped t -> Sem r Abstract.Module
+    goModule' (Module n par b) = case par of
+      [] -> Abstract.Module modName <$> goModuleBody b
+      _ -> unsupported "Module parameters"
+      where
+        modName :: Abstract.Name
+        modName = case sing :: SModuleIsTop t of
+          SModuleTop -> goSymbol (S.topModulePathName n)
+          SModuleLocal -> goSymbol n
 
 goName :: S.Name -> Abstract.Name
 goName = goSymbol . S.nameUnqualify
@@ -133,7 +129,7 @@ goStatement ::
 goStatement (Indexed idx s) =
   fmap (Indexed idx) <$> case s of
     StatementAxiom d -> Just . Abstract.StatementAxiom <$> goAxiom d
-    StatementImport (Import t) -> Just . Abstract.StatementImport <$> goModuleOrCache t
+    StatementImport (Import t) -> Just . Abstract.StatementImport <$> goModule t
     StatementOperator {} -> return Nothing
     StatementOpenModule o -> goOpenModule o
     StatementEval {} -> unsupported "eval statements"
@@ -155,7 +151,7 @@ goOpenModule o
       case o ^. openModuleName of
         ModuleRef' (SModuleTop :&: m) ->
           Just . Abstract.StatementImport
-            <$> goModuleOrCache (m ^. moduleRefModule)
+            <$> goModule (m ^. moduleRefModule)
         _ -> impossible
   | otherwise = return Nothing
 

--- a/src/MiniJuvix/Translation/ScopedToAbstract.hs
+++ b/src/MiniJuvix/Translation/ScopedToAbstract.hs
@@ -65,6 +65,17 @@ goModule (Module n par b) = case par of
       SModuleTop -> goSymbol (S.topModulePathName n)
       SModuleLocal -> goSymbol n
 
+goModuleOrCache ::
+  forall r.
+  Members '[InfoTableBuilder, Error ScoperError, Builtins, NameIdGen, State ModulesCache] r =>
+  Module 'Scoped 'ModuleTop ->
+  Sem r Abstract.Module
+goModuleOrCache m = do
+  cache <- gets (^. cachedModules)
+  let moduleNameId :: S.NameId
+      moduleNameId = m ^. Concrete.modulePath . S.nameId
+  maybe (goModule m) return (cache ^. at moduleNameId)
+
 goName :: S.Name -> Abstract.Name
 goName = goSymbol . S.nameUnqualify
 
@@ -122,11 +133,7 @@ goStatement ::
 goStatement (Indexed idx s) =
   fmap (Indexed idx) <$> case s of
     StatementAxiom d -> Just . Abstract.StatementAxiom <$> goAxiom d
-    StatementImport (Import t) -> do
-      cache <- gets (^. cachedModules)
-      let moduleNameId :: S.NameId
-          moduleNameId = t ^. Concrete.modulePath . S.nameId
-      Just . Abstract.StatementImport <$> maybe (goModule t) return (cache ^. at moduleNameId)
+    StatementImport (Import t) -> Just . Abstract.StatementImport <$> goModuleOrCache t
     StatementOperator {} -> return Nothing
     StatementOpenModule o -> goOpenModule o
     StatementEval {} -> unsupported "eval statements"
@@ -148,7 +155,7 @@ goOpenModule o
       case o ^. openModuleName of
         ModuleRef' (SModuleTop :&: m) ->
           Just . Abstract.StatementImport
-            <$> goModule (m ^. moduleRefModule)
+            <$> goModuleOrCache (m ^. moduleRefModule)
         _ -> impossible
   | otherwise = return Nothing
 

--- a/test/TypeCheck/Positive.hs
+++ b/test/TypeCheck/Positive.hs
@@ -86,5 +86,9 @@ tests =
     PosTest
       "Import a builtin multiple times"
       "BuiltinsMultiImport"
+      "Input.mjuvix",
+    PosTest
+      "open import a builtin multiple times"
+      "BuiltinsMultiOpenImport"
       "Input.mjuvix"
   ]

--- a/tests/positive/BuiltinsMultiOpenImport/A.mjuvix
+++ b/tests/positive/BuiltinsMultiOpenImport/A.mjuvix
@@ -1,0 +1,5 @@
+module A;
+
+open import Nat;
+
+end;

--- a/tests/positive/BuiltinsMultiOpenImport/Input.mjuvix
+++ b/tests/positive/BuiltinsMultiOpenImport/Input.mjuvix
@@ -1,0 +1,6 @@
+module Input;
+
+open import A;
+open import Nat;
+
+end;

--- a/tests/positive/BuiltinsMultiOpenImport/Nat.mjuvix
+++ b/tests/positive/BuiltinsMultiOpenImport/Nat.mjuvix
@@ -1,0 +1,9 @@
+module Nat;
+
+builtin natural
+inductive Nat {
+  zero : Nat;
+  suc : Nat → Nat;
+};
+
+end;


### PR DESCRIPTION
This follows on from https://github.com/heliaxdev/minijuvix/pull/223 and relates to #220 

```
import Data.Nat;
open Data.Nat;
```

The `open` statement causes `Data.Nat` to be processed. The previous PR added a cache for modules for `import` statements. This PR makes `open` statements use the same cache.