### PR TITLE
Filter symbol entries properly in the scoper

### DIFF
--- a/src/MiniJuvix/Syntax/Concrete/Language.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Language.hs
@@ -1125,6 +1125,14 @@ entryOverName f = snd . entryPrism f
 entryName :: SymbolEntry -> S.Name' ()
 entryName = fst . entryPrism id
 
+entryIsExpression :: SymbolEntry -> Bool
+entryIsExpression = \case
+  EntryAxiom {} -> True
+  EntryInductive {} -> True
+  EntryFunction {} -> True
+  EntryConstructor {} -> True
+  EntryModule {} -> False
+
 instance HasLoc SymbolEntry where
   getLoc = (^. S.nameDefined) . entryName
 

--- a/src/MiniJuvix/Syntax/Concrete/Scoped/Scoper.hs
+++ b/src/MiniJuvix/Syntax/Concrete/Scoped/Scoper.hs
@@ -316,7 +316,7 @@ checkQualifiedExpr ::
   QualifiedName ->
   Sem r ScopedIden
 checkQualifiedExpr q@(QualifiedName (Path p) sym) = do
-  es <- lookupQualifiedSymbol (toList p, sym)
+  es <- filter entryIsExpression <$> lookupQualifiedSymbol (toList p, sym)
   case es of
     [] -> notInScope
     [e] -> entryToScopedIden q' e

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -190,11 +190,11 @@ tests =
         ErrMultipleCompileBlockSameName {} -> Nothing
         _ -> wrongError,
     NegTest
-      "Multiple rules for a backend inside a compile block"
-      "CompileBlocks"
-      "MultipleCompileRuleSameBackend.mjuvix"
+      "issue 230"
+      "230"
+      "Prod.mjuvix"
       $ \case
-        ErrMultipleCompileRuleSameBackend {} -> Nothing
+        ErrQualSymNotInScope {} -> Nothing
         _ -> wrongError,
     NegTest
       "Compile block for a unsupported kind of expression"

--- a/test/Scope/Negative.hs
+++ b/test/Scope/Negative.hs
@@ -190,6 +190,13 @@ tests =
         ErrMultipleCompileBlockSameName {} -> Nothing
         _ -> wrongError,
     NegTest
+      "Multiple rules for a backend inside a compile block"
+      "CompileBlocks"
+      "MultipleCompileRuleSameBackend.mjuvix"
+      $ \case
+        ErrMultipleCompileRuleSameBackend {} -> Nothing
+        _ -> wrongError,
+    NegTest
       "issue 230"
       "230"
       "Prod.mjuvix"

--- a/tests/negative/230/Foo.mjuvix
+++ b/tests/negative/230/Foo.mjuvix
@@ -1,0 +1,5 @@
+module Foo;
+
+open import Foo.Data.Bool;
+
+end;

--- a/tests/negative/230/Foo/Data/Bool.mjuvix
+++ b/tests/negative/230/Foo/Data/Bool.mjuvix
@@ -1,0 +1,30 @@
+module Foo.Data.Bool;
+
+open import Prelude;
+
+import Data.Bool;
+
+  inductive Bool {
+    true : Bool;
+    false : Bool;
+  };
+
+  not : Bool → Bool;
+  not true ≔ false;
+  not false ≔ true;
+
+  infixr 2 ||;
+  || : Bool → Bool → Bool;
+  || false a ≔ a;
+  || true _ ≔ true;
+
+  infixr 2 &&;
+  && : Bool → Bool → Bool;
+  && false _ ≔ false;
+  && true a ≔ a;
+
+  if : {A : Type} → Bool → A → A → A;
+  if true a _ ≔ a;
+  if false _ b ≔ b;
+
+end;

--- a/tests/negative/230/Prod.mjuvix
+++ b/tests/negative/230/Prod.mjuvix
@@ -1,0 +1,10 @@
+module Prod;
+
+open import Prelude;
+open import Foo;
+     import Foo.Data.Bool;
+
+fi : Foo.Data.Bool;
+fi ≔ Foo.Data.Bool.false;
+
+end;


### PR DESCRIPTION
Fixes #230 
When scoping a qualified name in an expression, module entries are now filtered out, as they are not valid expressions.
The example given in #230 was added to the test suite