### PR TITLE
Add option to disable minijuvix input method

### DIFF
--- a/minijuvix-mode/minijuvix-input.el
+++ b/minijuvix-mode/minijuvix-input.el
@@ -170,8 +170,8 @@ This suffix is dropped."
   "The minijuvix input method.
 After tweaking these settings you may want to inspect the resulting
 translations using `minijuvix-input-show-translations'."
-  :group 'minijuvix2
-  :group 'leim)
+  :group 'minijuvix
+  )
 
 (defcustom minijuvix-input-tweak-all
   '(minijuvix-input-compose

--- a/minijuvix-mode/minijuvix-mode.el
+++ b/minijuvix-mode/minijuvix-mode.el
@@ -17,10 +17,17 @@
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.m?juvix\\'" . minijuvix-mode))
 
+(defcustom minijuvix-auto-input-method t
+  "Automatically set the input method in minijuvix files."
+  :type 'boolean
+  :group 'minijuvix)
+
 (define-derived-mode minijuvix-mode prog-mode "MiniJuvix"
 
   (font-lock-mode 0)
-  (set-input-method "minijuvix")
+  (when minijuvix-auto-input-method
+    (set-input-method "minijuvix")
+    )
   (setq-local comment-start "--")
 
   (add-hook


### PR DESCRIPTION
When `minijuvix-mode` is installed and the user visits a minijuvix buffer, the minijuvix input method is activated automatically. Now the user can disable this behaviour by adding this line to their config:
```
(setq minijuvix-auto-input-method nil)
```
Since this variable is defined through the [`defcustom`](https://www.gnu.org/software/emacs/manual/html_node/eintr/defcustom.html) macro, it can be set using the emacs interface as well.