### PR TITLE
Throw error when reading a file that conflicts with embedded stdlib

### DIFF
--- a/src/MiniJuvix/Pipeline.hs
+++ b/src/MiniJuvix/Pipeline.hs
@@ -25,7 +25,7 @@ import MiniJuvix.Translation.ScopedToAbstract qualified as Abstract
 type PipelineEff = '[Files, NameIdGen, Builtins, Error MiniJuvixError, Embed IO]
 
 runIOEither :: Sem PipelineEff a -> IO (Either MiniJuvixError a)
-runIOEither = runM . runError . runBuiltins . runNameIdGen . runFilesIO
+runIOEither = runM . runError . runBuiltins . runNameIdGen . mapError (MiniJuvixError @FilesError) . runFilesIO
 
 runIO :: Sem PipelineEff a -> IO a
 runIO = runIOEither >=> mayThrow

--- a/src/MiniJuvix/Prelude/Files/Error.hs
+++ b/src/MiniJuvix/Prelude/Files/Error.hs
@@ -1,0 +1,43 @@
+module MiniJuvix.Prelude.Files.Error where
+
+import MiniJuvix.Prelude.Base
+import MiniJuvix.Prelude.Error
+import MiniJuvix.Prelude.Pretty
+
+data FilesErrorCause = StdlibConflict
+  deriving stock (Show)
+
+data FilesError = FilesError
+  { _filesErrorPath :: FilePath,
+    _filesErrorCause :: FilesErrorCause
+  }
+  deriving stock (Show)
+
+instance ToGenericError FilesError where
+  genericError FilesError {..} =
+    GenericError
+      { _genericErrorLoc = i,
+        _genericErrorMessage = AnsiText (pretty @_ @AnsiStyle msg),
+        _genericErrorIntervals = [i]
+      }
+    where
+      i :: Interval
+      i =
+        Interval
+          { _intervalFile = _filesErrorPath,
+            _intervalStart = noFileLoc,
+            _intervalEnd = noFileLoc
+          }
+      msg :: Text
+      msg = case _filesErrorCause of
+        StdlibConflict -> "The module defined in " <> pack _filesErrorPath <> " conflicts with a module defined in the standard library."
+
+noFileLoc :: FileLoc
+noFileLoc =
+  FileLoc
+    { _locLine = mempty,
+      _locCol = mempty,
+      _locOffset = mempty
+    }
+
+makeLenses ''FilesError

--- a/test/Termination/Positive.hs
+++ b/test/Termination/Positive.hs
@@ -20,7 +20,7 @@ testDescr PosTest {..} =
         { _testName = _name,
           _testRoot = tRoot,
           _testAssertion = Single $ do
-            let entryPoint = defaultEntryPoint _file
+            let entryPoint = (defaultEntryPoint _file) {_entryPointNoStdlib = True}
             (void . runIO) (upToMicroJuvix entryPoint)
         }
 

--- a/tests/negative/StdlibConflict/Data/Bool.mjuvix
+++ b/tests/negative/StdlibConflict/Data/Bool.mjuvix
@@ -1,0 +1,3 @@
+module Bool;
+
+end;

--- a/tests/negative/StdlibConflict/Data/Bool.mjuvix
+++ b/tests/negative/StdlibConflict/Data/Bool.mjuvix
@@ -1,3 +1,3 @@
-module Bool;
+module Data.Bool;
 
 end;

--- a/tests/negative/StdlibConflict/Input.mjuvix
+++ b/tests/negative/StdlibConflict/Input.mjuvix
@@ -1,0 +1,5 @@
+module Input;
+
+open import Data.Bool;
+
+end;


### PR DESCRIPTION
The Files effect first tries to read a file from the embedded stdlib. If
this succeeds and the file also exists in the project then an error is
thrown.

This error can be thrown either at the parsing stage, if the entrypoint
file conflicts with the standard library, or at the scoping stage if an
imported file conflicts.

example:

```
cd tests/negative/StdlibConflict
minijuvix scope Input.mjuvix
/Users/paul/heliax/MiniJuvix/tests/negative/StdlibConflict/Data/Bool.mjuvix:0:0: error:
The module defined in /Users/paul/heliax/MiniJuvix/tests/negative/StdlibConflict/Data/Bool.mjuvix conflicts with a module defined in the standard library.
```

In a subsequent PR I'll add a prefix to the stdlib modules (as suggested by @janmasrovira  in https://github.com/heliaxdev/minijuvix/issues/222#issuecomment-1173414695) to make standard library conflicts less likely.

Closes #222 