### PR TITLE
Add emacs option `minijuvix-disable-embedded-stdlib`

### DIFF
--- a/minijuvix-mode/flycheck-minijuvix.el
+++ b/minijuvix-mode/flycheck-minijuvix.el
@@ -1,4 +1,5 @@
 (require 'flycheck)
+(require 'minijuvix-customize)
 
 (defgroup flycheck-minijuvix nil
   "MiniJuvix support for Flycheck."
@@ -9,7 +10,8 @@
 (flycheck-define-checker minijuvix
   "A MiniJuvix syntax checker."
   :command ("minijuvix" "microjuvix" "typecheck" "--only-errors" "--no-colors"
-                source-original)
+            (option-flag "--no-stdlib" minijuvix-disable-embedded-stdlib)
+            source-original)
   :error-patterns
     (
      (error line-start (file-name) ":" line ":" column ": error:" (message (one-or-more (not "ת"))))

--- a/minijuvix-mode/minijuvix-customize.el
+++ b/minijuvix-mode/minijuvix-customize.el
@@ -1,0 +1,12 @@
+
+(defcustom minijuvix-auto-input-method t
+  "Automatically set the input method in minijuvix files."
+  :type 'boolean
+  :group 'minijuvix)
+
+(defcustom minijuvix-disable-embedded-stdlib nil
+  "Disable the embedded standard library."
+  :type 'boolean
+  :group 'minijuvix)
+
+(provide 'minijuvix-customize)

--- a/minijuvix-mode/minijuvix-mode.el
+++ b/minijuvix-mode/minijuvix-mode.el
@@ -1,3 +1,4 @@
+(require 'minijuvix-customize)
 (require 'minijuvix-highlight)
 (require 'minijuvix-input)
 (require 'flycheck-minijuvix)
@@ -16,11 +17,6 @@
 
 ;;;###autoload
 (add-to-list 'auto-mode-alist '("\\.m?juvix\\'" . minijuvix-mode))
-
-(defcustom minijuvix-auto-input-method t
-  "Automatically set the input method in minijuvix files."
-  :type 'boolean
-  :group 'minijuvix)
 
 (define-derived-mode minijuvix-mode prog-mode "MiniJuvix"
 
@@ -52,7 +48,7 @@
   (interactive)
   (save-buffer)
   (minijuvix-clear-annotations)
-  (eval (read (shell-command-to-string (concat "minijuvix highlight " (buffer-file-name)))))
+  (eval (read (shell-command-to-string (concat "minijuvix highlight " (if minijuvix-disable-embedded-stdlib "--no-stdlib " "") (buffer-file-name)))))
   (save-buffer)
   )
 


### PR DESCRIPTION
When developing the stdlib or any other project that doesn't use the
embedded standard library, the `--no-stdlib` flag must be set on the
compiler commands.

This PR adds an emacs custom option `minijuvix-disable-embedded-stdlib` to set`--no-stdlib` for highlight and flycheck.