### PR TITLE
Enforce C99 standard in the generated C files

### DIFF
--- a/app/Commands/Compile.hs
+++ b/app/Commands/Compile.hs
@@ -160,6 +160,7 @@ libcArgs sysrootPath wasmOutputFile inputFile =
 commonArgs :: FilePath -> FilePath -> [String]
 commonArgs sysrootPath wasmOutputFile =
   [ "-nodefaultlibs",
+    "-std=c99",
     "-Oz",
     "-I",
     minijuvixBuildDir,

--- a/test/BackendC/Base.hs
+++ b/test/BackendC/Base.hs
@@ -62,6 +62,7 @@ builtinRuntime = $(makeRelativeToProject "minic-runtime/builtins" >>= strToExp)
 standaloneArgs :: FilePath -> FilePath -> FilePath -> [String]
 standaloneArgs sysrootPath wasmOutputFile cOutputFile =
   [ "-nodefaultlibs",
+    "-std=c99",
     "-I",
     takeDirectory minicRuntime,
     "-I",
@@ -84,6 +85,7 @@ standaloneArgs sysrootPath wasmOutputFile cOutputFile =
 libcArgs :: FilePath -> FilePath -> FilePath -> [String]
 libcArgs sysrootPath wasmOutputFile cOutputFile =
   [ "-nodefaultlibs",
+    "-std=c99",
     "-I",
     takeDirectory minicRuntime,
     "-I",


### PR DESCRIPTION
In order to avoid accidental reliance on non-standard C extensions, I added '-std=c99' to clang options.
